### PR TITLE
First cut at fixing update-data

### DIFF
--- a/include/linalg.h
+++ b/include/linalg.h
@@ -194,8 +194,9 @@ void row_inf_norm(const QOCOCscMatrix* M, QOCOFloat* norm);
  * @brief Allocates and computes A^T.
  *
  * @param A Input matrix.
+ * @param AtoAt Mapping from A to At.
  */
-QOCOCscMatrix* create_transposed_matrix(const QOCOCscMatrix* A);
+QOCOCscMatrix* create_transposed_matrix(const QOCOCscMatrix* A, QOCOInt* AtoAt);
 
 /**
  * @brief Scales the rows of M by E and columns of M by D.

--- a/include/structs.h
+++ b/include/structs.h
@@ -232,11 +232,11 @@ typedef struct {
   /** Number of elements of P->x that were added due to regularization. */
   QOCOInt Pnum_nzadded;
 
-  /** Mapping from elements in A to elements in the KKT matrix. */
-  QOCOInt* AtoKKT;
+  /** Mapping from elements in At to elements in the KKT matrix. */
+  QOCOInt* AttoKKT;
 
-  /** Mapping from elements in G to elements in the KKT matrix. */
-  QOCOInt* GtoKKT;
+  /** Mapping from elements in Gt to elements in the KKT matrix. */
+  QOCOInt* GttoKKT;
 
 } QOCOKKT;
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -69,6 +69,12 @@ typedef struct {
   /** Transpose of G (used in Ruiz for fast row norm calculations of G). */
   QOCOCscMatrix* Gt;
 
+  /** Mapping from A to At. */
+  QOCOInt* AtoAt;
+
+  /** Mapping from G to Gt. */
+  QOCOInt* GtoGt;
+
   /** Conic constraint offset. */
   QOCOFloat* h;
 

--- a/src/cone.c
+++ b/src/cone.c
@@ -343,7 +343,7 @@ QOCOFloat exact_linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
   }
 
   if (-f < minval)
-    a = 1;
+    a = f;
   else
     a = -f / minval;
 

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -56,7 +56,7 @@ void construct_kkt(QOCOSolver* solver)
     for (QOCOInt k = work->data->At->p[Atcol]; k < work->data->At->p[Atcol + 1];
          ++k) {
       // If the nonzero is in row i of A then add
-      work->kkt->AtoKKT[k] = nz;
+      work->kkt->AttoKKT[k] = nz;
       work->kkt->K->x[nz] = work->data->At->x[k];
       work->kkt->K->i[nz] = work->data->At->i[k];
       nz += 1;
@@ -81,7 +81,7 @@ void construct_kkt(QOCOSolver* solver)
     QOCOInt nzadded = 0;
     for (QOCOInt k = work->data->Gt->p[Gtcol]; k < work->data->Gt->p[Gtcol + 1];
          ++k) {
-      work->kkt->GtoKKT[k] = nz;
+      work->kkt->GttoKKT[k] = nz;
       work->kkt->K->x[nz] = work->data->Gt->x[k];
       work->kkt->K->i[nz] = work->data->Gt->i[k];
       nz += 1;
@@ -114,7 +114,7 @@ void construct_kkt(QOCOSolver* solver)
       QOCOInt nzadded = 0;
       for (QOCOInt k = work->data->Gt->p[Gtcol];
            k < work->data->Gt->p[Gtcol + 1]; ++k) {
-        work->kkt->GtoKKT[k] = nz;
+        work->kkt->GttoKKT[k] = nz;
         work->kkt->K->x[nz] = work->data->Gt->x[k];
         work->kkt->K->i[nz] = work->data->Gt->i[k];
         nz += 1;

--- a/src/linalg.c
+++ b/src/linalg.c
@@ -332,7 +332,7 @@ void row_inf_norm(const QOCOCscMatrix* M, QOCOFloat* norm)
   }
 }
 
-QOCOCscMatrix* create_transposed_matrix(const QOCOCscMatrix* A)
+QOCOCscMatrix* create_transposed_matrix(const QOCOCscMatrix* A, QOCOInt* AtoAt)
 {
   QOCOCscMatrix* B = qoco_malloc(sizeof(QOCOCscMatrix));
   B->m = A->n;
@@ -365,6 +365,7 @@ QOCOCscMatrix* create_transposed_matrix(const QOCOCscMatrix* A)
       int dest_pos = B->p[row] + temp[row];
       B->i[dest_pos] = j;       // Column index becomes row index
       B->x[dest_pos] = A->x[i]; // Value remains the same
+      AtoAt[i] = dest_pos;
       temp[row]++;
     }
   }

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -112,9 +112,9 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   solver->work->kkt->ntdiag2kkt = qoco_calloc(m, sizeof(QOCOInt));
   solver->work->kkt->PregtoKKT =
       qoco_calloc(solver->work->data->P->nnz, sizeof(QOCOInt));
-  solver->work->kkt->AtoKKT =
+  solver->work->kkt->AttoKKT =
       qoco_calloc(solver->work->data->A->nnz, sizeof(QOCOInt));
-  solver->work->kkt->GtoKKT =
+  solver->work->kkt->GttoKKT =
       qoco_calloc(solver->work->data->G->nnz, sizeof(QOCOInt));
   solver->work->kkt->rhs = qoco_malloc((n + m + p) * sizeof(QOCOFloat));
   solver->work->kkt->kktres = qoco_malloc((n + m + p) * sizeof(QOCOFloat));
@@ -201,11 +201,11 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   }
 
   for (QOCOInt i = 0; i < solver->work->data->A->nnz; ++i) {
-    solver->work->kkt->AtoKKT[i] = KtoPKPt[solver->work->kkt->AtoKKT[i]];
+    solver->work->kkt->AttoKKT[i] = KtoPKPt[solver->work->kkt->AttoKKT[i]];
   }
 
   for (QOCOInt i = 0; i < solver->work->data->G->nnz; ++i) {
-    solver->work->kkt->GtoKKT[i] = KtoPKPt[solver->work->kkt->GtoKKT[i]];
+    solver->work->kkt->GttoKKT[i] = KtoPKPt[solver->work->kkt->GttoKKT[i]];
   }
 
   free_qoco_csc_matrix(solver->work->kkt->K);
@@ -388,14 +388,14 @@ void update_matrix_data(QOCOSolver* solver, QOCOFloat* Pxnew, QOCOFloat* Axnew,
   // Update A in KKT matrix.
   for (QOCOInt i = 0; i < data->A->nnz; ++i) {
     solver->work->kkt->K
-        ->x[solver->work->kkt->AtoKKT[solver->work->data->AtoAt[i]]] =
+        ->x[solver->work->kkt->AttoKKT[solver->work->data->AtoAt[i]]] =
         data->A->x[i];
   }
 
   // Update G in KKT matrix.
   for (QOCOInt i = 0; i < data->G->nnz; ++i) {
     solver->work->kkt->K
-        ->x[solver->work->kkt->GtoKKT[solver->work->data->GtoGt[i]]] =
+        ->x[solver->work->kkt->GttoKKT[solver->work->data->GtoGt[i]]] =
         data->G->x[i];
   }
 }
@@ -522,8 +522,8 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
   qoco_free(solver->work->kkt->ntdiag2kkt);
   qoco_free(solver->work->kkt->Pnzadded_idx);
   qoco_free(solver->work->kkt->PregtoKKT);
-  qoco_free(solver->work->kkt->AtoKKT);
-  qoco_free(solver->work->kkt->GtoKKT);
+  qoco_free(solver->work->kkt->AttoKKT);
+  qoco_free(solver->work->kkt->GttoKKT);
   qoco_free(solver->work->kkt->etree);
   qoco_free(solver->work->kkt->Lnz);
   qoco_free(solver->work->kkt->Lp);

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -82,8 +82,15 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   solver->work->kkt->Dinvruiz = qoco_malloc(n * sizeof(QOCOFloat));
   solver->work->kkt->Einvruiz = qoco_malloc(p * sizeof(QOCOFloat));
   solver->work->kkt->Finvruiz = qoco_malloc(m * sizeof(QOCOFloat));
-  solver->work->data->At = create_transposed_matrix(solver->work->data->A);
-  solver->work->data->Gt = create_transposed_matrix(solver->work->data->G);
+  solver->work->data->AtoAt =
+      qoco_malloc(solver->work->data->A->nnz * sizeof(QOCOInt));
+  solver->work->data->GtoGt =
+      qoco_malloc(solver->work->data->G->nnz * sizeof(QOCOInt));
+
+  solver->work->data->At = create_transposed_matrix(solver->work->data->A,
+                                                    solver->work->data->AtoAt);
+  solver->work->data->Gt = create_transposed_matrix(solver->work->data->G,
+                                                    solver->work->data->GtoGt);
   ruiz_equilibration(solver);
 
   // Regularize P.
@@ -380,12 +387,16 @@ void update_matrix_data(QOCOSolver* solver, QOCOFloat* Pxnew, QOCOFloat* Axnew,
 
   // Update A in KKT matrix.
   for (QOCOInt i = 0; i < data->A->nnz; ++i) {
-    solver->work->kkt->K->x[solver->work->kkt->AtoKKT[i]] = data->A->x[i];
+    solver->work->kkt->K
+        ->x[solver->work->kkt->AtoKKT[solver->work->data->AtoAt[i]]] =
+        data->A->x[i];
   }
 
   // Update G in KKT matrix.
   for (QOCOInt i = 0; i < data->G->nnz; ++i) {
-    solver->work->kkt->K->x[solver->work->kkt->GtoKKT[i]] = data->G->x[i];
+    solver->work->kkt->K
+        ->x[solver->work->kkt->GtoKKT[solver->work->data->GtoGt[i]]] =
+        data->G->x[i];
   }
 }
 
@@ -461,6 +472,8 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
   free_qoco_csc_matrix(solver->work->data->At);
   free_qoco_csc_matrix(solver->work->data->Gt);
 
+  qoco_free(solver->work->data->AtoAt);
+  qoco_free(solver->work->data->GtoGt);
   qoco_free(solver->work->data->b);
   qoco_free(solver->work->data->c);
   qoco_free(solver->work->data->h);


### PR DESCRIPTION
Previously, the maps which were intended to be AtoKKT and GtoKKT were actually AttoKKT and GttoKKT since in the kkt construction function, we insert the transposes of A and G into K. 

This pr adds the mappings AtoAt and GtoGt which we can compose with AttoKKT and GttoKKT to do the mappings AtoKKT and GtoKKT.

However, to update the elements of the KKT matrix we have some memory indirection as we must index into AtoAt then AttoKKT, which could cause some performance issue for large data updates. But that can be put off until it becomes an issue.