### PR TITLE
Speed up P regularization

### DIFF
--- a/include/qoco_linalg.h
+++ b/include/qoco_linalg.h
@@ -151,16 +151,27 @@ void SpMtv(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r);
 QOCOFloat inf_norm(const QOCOFloat* x, QOCOInt n);
 
 /**
- * @brief Adds lambda * I to a CSC matrix. Called on P prior to construction of
- * KKT system in qoco_setup(). This function calls realloc() when adding new
- * nonzeros.
+ * @brief Counts the number of diagonal elements in upper triangular CSC matrix
+ * M.
  *
- * @param M Matrix to be regularized.
- * @param lambda Regularization factor.
- * @param nzadded_idx Indices of elements of M->x that are added.
- * @return Number of nonzeros added to M->x.
+ * @param M Input matrix.
+ * @return Number of nonzeros on the diagonal of M.
  */
-QOCOInt regularize(QOCOCscMatrix* M, QOCOFloat lambda, QOCOInt* nzadded_idx);
+QOCOInt count_diag(QOCOCscMatrix* M);
+
+/**
+ * @brief Adds reg * I to a CSC matrix. Called on P prior to construction
+ * of KKT system in qoco_setup(). This function calls realloc() when adding
+ * new nonzeros. Matrix P is freed using free_qoco_csc_matrix
+ *
+ * @param num_diagP Number of new element added to diagonal.
+ * @param P Matrix to be regularized.
+ * @param reg Regularization factor.
+ * @param nzadded_idx Indices of elements of M->x that are added.
+ * @return P + reg * I.
+ */
+QOCOCscMatrix* regularize_P(QOCOInt num_diagP, QOCOCscMatrix* P, QOCOFloat reg,
+                            QOCOInt* nzadded_idx);
 
 /**
  * @brief Subtracts lambda * I to a CSC matrix. Called on P when updating

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -96,9 +96,12 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   // Regularize P.
   solver->work->kkt->Pnzadded_idx = qoco_calloc(n, sizeof(QOCOInt));
   if (P) {
-    solver->work->kkt->Pnum_nzadded =
-        regularize(solver->work->data->P, solver->settings->kkt_static_reg,
-                   solver->work->kkt->Pnzadded_idx);
+    QOCOInt num_diagP = count_diag(P);
+    solver->work->kkt->Pnum_nzadded = n - num_diagP;
+    QOCOCscMatrix* Preg = regularize_P(num_diagP, solver->work->data->P,
+                                       solver->settings->kkt_static_reg,
+                                       solver->work->kkt->Pnzadded_idx);
+    solver->work->data->P = Preg;
   }
   else {
     solver->work->data->P =


### PR DESCRIPTION
Previously, the `regularize` function for P was very naive and called `realloc` every time a new element needed to be added on the diagonal of P. This caused massive slowdown for very large QPs.