### PR TITLE
Support single precision floats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,17 @@ message(STATUS "Build Flags: " ${CMAKE_C_FLAGS})
 message(STATUS "Using 32 bit integers")
 set(QDLDL_LONG OFF)
 
-# Set floating points to double precision.
-message(STATUS "Using double precision floating point")
+# Option for single precision floating point.
+option(QOCO_SINGLE_PRECISION "Use single precision (float) instead of double precision" OFF)
+
+# Set floating points precision.
+if(QOCO_SINGLE_PRECISION)
+    message(STATUS "Using single precision floating point")
+    add_compile_definitions(QOCO_SINGLE_PRECISION)
+    set(QDLDL_FLOAT ON CACHE BOOL "Use float numbers instead of doubles" FORCE)
+else()
+    message(STATUS "Using double precision floating point")
+endif()
 
 # Add -fPIC option explicity.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/devtools/run_tests.sh
+++ b/devtools/run_tests.sh
@@ -1,1 +1,1 @@
-export CXX=/usr/local/bin/clang++ && export CC=/usr/local/bin/clang && cd build && cmake -DQOCO_BUILD_TYPE:STR=Release -DENABLE_TESTING:BOOL=True -DBUILD_QOCO_BENCHMARK_RUNNER:BOOL=True .. && make && ctest --verbose && cd ..
+export CXX=/usr/local/bin/clang++ && export CC=/usr/local/bin/clang && cd build && cmake -DQOCO_BUILD_TYPE:STR=Release -DQOCO_SINGLE_PRECISION:BOOL=True -DENABLE_TESTING:BOOL=True -DBUILD_QOCO_BENCHMARK_RUNNER:BOOL=True .. && make && ctest --verbose && cd ..

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -26,11 +26,20 @@ typedef int QOCOInt;
 #define printf mexPrintf
 #endif
 
+#ifdef QOCO_SINGLE_PRECISION
+typedef float QOCOFloat;
+#ifdef IS_WINDOWS
+#define QOCOFloat_MAX 3.4e38f
+#else
+#define QOCOFloat_MAX __FLT_MAX__
+#endif
+#else
 typedef double QOCOFloat;
 #ifdef IS_WINDOWS
 #define QOCOFloat_MAX 1e308
 #else
 #define QOCOFloat_MAX __DBL_MAX__
+#endif
 #endif
 
 #define qoco_max(a, b) (((a) > (b)) ? (a) : (b))


### PR DESCRIPTION
Allows QOCO to use single precision floats. To use single precision, pass in the CMake flag: `-DQOCO_SINGLE_PRECISION:BOOL=True`. 

When single precision is used, there is a drop in robustness and the main advantage is saving memory for resource constrained embedded systems.

It is recommended to reduce the solver tolerances and increase regularization of the KKT system. Recommended settings are:

``` 
kkt_static_reg = 1e-5
kkt_dynamic_reg = 1e-5
abstol = 1e-5
reltol = 1e-5
```
