### PR TITLE
Use dlopen for cuda libraries

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -94,7 +94,7 @@ jobs:
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
       - name: Build on Mac or Ubuntu
-        if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
         # Build your program with the given configuration.
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,10 @@ get_property(qoco_cuda_libs GLOBAL PROPERTY QOCO_CUDA_LIBS)
 # Build qoco shared library.
 add_library(qoco SHARED)
 target_link_libraries(qoco qdldlobject amd)
-target_link_libraries(qoco ${qoco_cuda_libs})
+# CUDA libraries are loaded dynamically via dlopen() in cudss_setup()
+if(IS_LINUX OR IS_MACOS)
+    target_link_libraries(qoco dl)
+endif()
 
 if(IS_LINUX OR IS_MACOS)
     target_link_libraries(qoco m)
@@ -152,7 +155,10 @@ target_sources(qoco PRIVATE ${qoco_sources})
 # Build qoco static library.
 add_library(qocostatic STATIC)
 target_link_libraries(qocostatic qdldlobject amd)
-target_link_libraries(qocostatic ${qoco_cuda_libs})
+# CUDA libraries are loaded dynamically via dlopen() in cudss_setup()
+if(IS_LINUX OR IS_MACOS)
+    target_link_libraries(qocostatic dl)
+endif()
 
 if(IS_LINUX OR IS_MACOS)
     target_link_libraries(qocostatic m)

--- a/algebra/cuda/cudss_backend.h
+++ b/algebra/cuda/cudss_backend.h
@@ -31,6 +31,51 @@ extern "C" {
 #endif
 #include "structs.h"
 
+// Structure to hold function pointers for CUDA libraries
+typedef struct {
+  // cuDSS function pointers
+  cudssStatus_t (*cudssCreate)(cudssHandle_t* handle);
+  cudssStatus_t (*cudssConfigCreate)(cudssConfig_t* config);
+  cudssStatus_t (*cudssDataCreate)(cudssHandle_t handle, cudssData_t* data);
+  cudssStatus_t (*cudssMatrixCreateCsr)(cudssMatrix_t* mat, int64_t rows, int64_t cols, 
+                                         int64_t nnz, void* csrRowPtr, void* csrRowPtr_type,
+                                         void* csrColInd, void* csrVal,
+                                         cudaDataType_t idxType, cudaDataType_t valType,
+                                         cudssMatrixType_t type, int view,
+                                         cudssIndexBase_t base);
+  cudssStatus_t (*cudssExecute)(cudssHandle_t handle, cudssPhase_t phase,
+                                 cudssConfig_t config, cudssData_t data,
+                                 cudssMatrix_t matA, cudssMatrix_t matB, cudssMatrix_t matC);
+  cudssStatus_t (*cudssMatrixCreateDn)(cudssMatrix_t* mat, int64_t rows, int64_t cols,
+                                        int64_t ld, void* data, cudaDataType_t type,
+                                        int layout);
+  cudssStatus_t (*cudssMatrixSetValues)(cudssMatrix_t mat, void* data);
+  cudssStatus_t (*cudssMatrixDestroy)(cudssMatrix_t mat);
+  cudssStatus_t (*cudssDataDestroy)(cudssHandle_t handle, cudssData_t data);
+  cudssStatus_t (*cudssConfigDestroy)(cudssConfig_t config);
+  cudssStatus_t (*cudssDestroy)(cudssHandle_t handle);
+  
+  // cuSPARSE function pointers
+  cusparseStatus_t (*cusparseCreate)(cusparseHandle_t* handle);
+  cusparseStatus_t (*cusparseCreateMatDescr)(cusparseMatDescr_t* descr);
+  cusparseStatus_t (*cusparseSetMatType)(cusparseMatDescr_t descr, cusparseMatrixType_t type);
+  cusparseStatus_t (*cusparseSetMatIndexBase)(cusparseMatDescr_t descr, cusparseIndexBase_t base);
+  cusparseStatus_t (*cusparseDestroy)(cusparseHandle_t handle);
+  cusparseStatus_t (*cusparseDestroyMatDescr)(cusparseMatDescr_t descr);
+  
+  // cuBLAS function pointers
+  cublasStatus_t (*cublasCreate)(cublasHandle_t* handle);
+  cublasStatus_t (*cublasDdot)(cublasHandle_t handle, int n, const double* x, int incx, const double* y, int incy, double* result);
+  cublasStatus_t (*cublasDestroy)(cublasHandle_t handle);
+} CudaLibFuncs;
+
+// Accessor function for CUDA library function pointers
+// Note: Call load_cuda_libraries() before using these pointers
+CudaLibFuncs* get_cuda_funcs(void);
+
+// Load CUDA libraries dynamically (must be called before using CUDA library functions)
+int load_cuda_libraries(void);
+
 extern LinSysBackend backend;
 
 #endif /* #ifndef CUDSS_BACKEND_H */

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -49,7 +49,7 @@ typedef double QOCOFloat;
 #include <math.h>
 #define qoco_sqrt(a) sqrt(a)
 
-#if defined(QOCO_DEBUG) && !defined(IS_WINDOWS)
+#if defined(QOCO_DEBUG) && defined(IS_LINUX)
 #include <assert.h>
 #include <stdio.h>
 #define qoco_assert(a)                                                         \


### PR DESCRIPTION
This is necessary to reduce bloat of `qoco-cuda` wheels.

When the cuda libraries are dynamically linked in the CMakeLists.txt, when the wheels are built for manylinux, all cuda libraries are packaged into the wheel leading to a wheel which is ~600MB. With this fix, the wheels are ~400kB