### PR TITLE
[DRAFT] Move solve to GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,12 @@ if(NOT DEFINED QOCO_ALGEBRA_BACKEND)
     set(QOCO_ALGEBRA_BACKEND "builtin" CACHE STRING "The Algebra to use")
 endif()
 message(STATUS "Using ${QOCO_ALGEBRA_BACKEND} algebra")
+# Propagate backend choice to all targets
+if(${QOCO_ALGEBRA_BACKEND} STREQUAL "cuda")
+    add_compile_definitions(QOCO_ALGEBRA_BACKEND_CUDA)
+else()
+    add_compile_definitions(QOCO_ALGEBRA_BACKEND_BUILTIN)
+endif()
 
 # Enable CUDA if using CUDA backend
 if(${QOCO_ALGEBRA_BACKEND} STREQUAL "cuda")

--- a/algebra/builtin/builtin_linalg.c
+++ b/algebra/builtin/builtin_linalg.c
@@ -99,6 +99,8 @@ QOCOInt get_length_vectorf(const QOCOVectorf* x) { return x->len; }
 
 // No-op for builtin backend
 void sync_vector_to_host(QOCOVectorf* v) {}
+// No-op for builtin backend
+void sync_vector_to_device(const QOCOVectorf* v) {}
 
 // No-op for builtin backend
 void set_solve_phase(int active) {}

--- a/algebra/builtin/builtin_linalg.c
+++ b/algebra/builtin/builtin_linalg.c
@@ -103,6 +103,9 @@ void sync_vector_to_host(QOCOVectorf* v) {}
 // No-op for builtin backend
 void set_solve_phase(int active) {}
 
+// No-op for builtin backend
+void set_scaling_statistics_mode(int active) {}
+
 QOCOCscMatrix* get_csc_matrix(const QOCOMatrix* M) { return M->csc; }
 
 void col_inf_norm_USymm_matrix(const QOCOMatrix* M, QOCOFloat* norm)

--- a/algebra/builtin/qdldl_backend.c
+++ b/algebra/builtin/qdldl_backend.c
@@ -205,7 +205,7 @@ static void qdldl_solve(LinSysData* linsys_data, QOCOWorkspace* work,
       x[linsys_data->p[k]] = linsys_data->xyzbuff1[k];
     }
 
-    kkt_multiply(x, linsys_data->xyzbuff2, work->data, work->Wfull, work->xbuff,
+    kkt_multiply(x, linsys_data->xyzbuff2, work->data, work->Wfull, get_data_vectorf(work->xbuff),
                  work->ubuff1, work->ubuff2);
     for (QOCOInt k = 0; k < linsys_data->K->n; ++k) {
       x[k] = linsys_data->xyzbuff2[linsys_data->p[k]];

--- a/algebra/cuda/cuda_linalg.cu
+++ b/algebra/cuda/cuda_linalg.cu
@@ -166,19 +166,13 @@ QOCOFloat* get_pointer_vectorf(const QOCOVectorf* x, QOCOInt idx)
   return &x->data[idx];
 }
 
-// TODO: remove set_solve_phase and solve_phase_active. Now we need them, since equilibration is done on CPU (requiring get_data_vectorf to return a host pointer) and solve is done on GPU.
-// Track solve phase to determine if we should return device or host pointers
-static int solve_phase_active = 0;
-
-void set_solve_phase(int active) { solve_phase_active = active; }
-
 QOCOFloat* get_data_vectorf(const QOCOVectorf* x)
 {
   // During equilibration/setup (CPU phase), return host pointer
   // During solve (GPU phase), return device pointer to avoid CPU-GPU copies
-  if (solve_phase_active && x->d_data) {
-    return x->d_data;
-  }
+  // if (x->d_data) {
+  //   return x->d_data;
+  // }
   return x->data;
 }
 

--- a/algebra/cuda/cuda_linalg.cu
+++ b/algebra/cuda/cuda_linalg.cu
@@ -98,26 +98,36 @@ QOCOMatrix* new_qoco_matrix(const QOCOCscMatrix* A)
     Mcsc->p = p;
     M->csc = Mcsc;
 
-    // Allocate device CSC matrix
-    QOCOCscMatrix* d_Mcsc = (QOCOCscMatrix*)qoco_malloc(sizeof(QOCOCscMatrix));
+    // Allocate device CSC matrix structure and data
+    QOCOCscMatrix* d_Mcsc;
     QOCOFloat* d_x;
     QOCOInt* d_p;
     QOCOInt* d_i;
     
+    // Allocate structure on device
+    CUDA_CHECK(cudaMalloc(&d_Mcsc, sizeof(QOCOCscMatrix)));
     CUDA_CHECK(cudaMalloc(&d_x, nnz * sizeof(QOCOFloat)));
     CUDA_CHECK(cudaMalloc(&d_p, (n + 1) * sizeof(QOCOInt)));
     CUDA_CHECK(cudaMalloc(&d_i, nnz * sizeof(QOCOInt)));
     
+    // Copy data to device
     CUDA_CHECK(cudaMemcpy(d_x, x, nnz * sizeof(QOCOFloat), cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaMemcpy(d_p, p, (n + 1) * sizeof(QOCOInt), cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaMemcpy(d_i, i, nnz * sizeof(QOCOInt), cudaMemcpyHostToDevice));
     
-    d_Mcsc->m = m;
-    d_Mcsc->n = n;
-    d_Mcsc->nnz = nnz;
-    d_Mcsc->x = d_x;
-    d_Mcsc->i = d_i;
-    d_Mcsc->p = d_p;
+    // Create structure on host with device pointers, then copy to device
+    QOCOCscMatrix h_d_Mcsc;
+    h_d_Mcsc.m = m;
+    h_d_Mcsc.n = n;
+    h_d_Mcsc.nnz = nnz;
+    h_d_Mcsc.x = d_x;
+    h_d_Mcsc.i = d_i;
+    h_d_Mcsc.p = d_p;
+    
+    // Copy structure to device
+    CUDA_CHECK(cudaMemcpy(d_Mcsc, &h_d_Mcsc, sizeof(QOCOCscMatrix), cudaMemcpyHostToDevice));
+    
+    // Store device pointer for kernel calls
     M->d_csc = d_Mcsc;
   }
   else {
@@ -170,10 +180,17 @@ void free_qoco_matrix(QOCOMatrix* A)
     
     // Free device CSC matrix if allocated
     if (A->d_csc) {
-      if (A->d_csc->x) cudaFree(A->d_csc->x);
-      if (A->d_csc->i) cudaFree(A->d_csc->i);
-      if (A->d_csc->p) cudaFree(A->d_csc->p);
-      qoco_free(A->d_csc);
+      // Copy structure from device to get data pointers for cleanup
+      QOCOCscMatrix d_csc_host;
+      CUDA_CHECK(cudaMemcpy(&d_csc_host, A->d_csc, sizeof(QOCOCscMatrix), cudaMemcpyDeviceToHost));
+      
+      // Free device data arrays
+      if (d_csc_host.x) cudaFree(d_csc_host.x);
+      if (d_csc_host.i) cudaFree(d_csc_host.i);
+      if (d_csc_host.p) cudaFree(d_csc_host.p);
+      
+      // Free device structure
+      cudaFree(A->d_csc);
     }
     
     qoco_free(A);
@@ -560,6 +577,41 @@ __global__ void USpMv_kernel(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFlo
   }
 }
 
+// CUDA kernel for device-side SpMv
+// Each thread handles one column of the matrix
+__global__ void SpMv_kernel(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r)
+{
+  QOCOInt col = blockIdx.x;
+  if (col >= M->n) return;
+  
+  // Process all nonzeros in column col
+  for (QOCOInt idx = M->p[col]; idx < M->p[col + 1]; idx++) {
+    QOCOInt row = M->i[idx];
+    QOCOFloat val = M->x[idx] * v[col];
+    
+    // Add to r[row] using atomic (multiple columns can write to same row)
+    atomicAdd(&r[row], val);
+  }
+}
+
+// CUDA kernel for device-side SpMtv
+// Each thread handles one column of the result
+__global__ void SpMtv_kernel(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r)
+{
+  QOCOInt col = blockIdx.x;
+  if (col >= M->n) return;
+  
+  QOCOFloat sum = 0.0;
+  
+  // Process all nonzeros in column col
+  for (QOCOInt idx = M->p[col]; idx < M->p[col + 1]; idx++) {
+    QOCOInt row = M->i[idx];
+    sum += M->x[idx] * v[row];
+  }
+  
+  r[col] = sum;
+}
+
 // Host function that handles both host and device pointers
 // Requires that matrix and vectors are all on the same memory space (all CPU or all GPU)
 void USpMv(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r)
@@ -568,50 +620,54 @@ void USpMv(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r)
   qoco_assert(v);
   qoco_assert(r);
 
-  // Check if matrix data pointers are on device
-  cudaPointerAttributes attrs_Mx, attrs_Mp, attrs_Mi;
-  cudaError_t err_Mx = cudaPointerGetAttributes(&attrs_Mx, M->x);
-  cudaError_t err_Mp = cudaPointerGetAttributes(&attrs_Mp, M->p);
-  cudaError_t err_Mi = cudaPointerGetAttributes(&attrs_Mi, M->i);
-
-  // Check if vector pointers are on device
+  // Check if vector pointers are on device first
   cudaPointerAttributes attrs_v, attrs_r;
   cudaError_t err_v = cudaPointerGetAttributes(&attrs_v, v);
   cudaError_t err_r = cudaPointerGetAttributes(&attrs_r, r);
-
-  // Determine if matrix data is on device
-  int Mx_is_device = (err_Mx == cudaSuccess && attrs_Mx.type == cudaMemoryTypeDevice);
-  int Mp_is_device = (err_Mp == cudaSuccess && attrs_Mp.type == cudaMemoryTypeDevice);
-  int Mi_is_device = (err_Mi == cudaSuccess && attrs_Mi.type == cudaMemoryTypeDevice);
-  int M_is_device = Mx_is_device || Mp_is_device || Mi_is_device;
 
   // Determine if vectors are on device
   int v_is_device = (err_v == cudaSuccess && attrs_v.type == cudaMemoryTypeDevice);
   int r_is_device = (err_r == cudaSuccess && attrs_r.type == cudaMemoryTypeDevice);
 
-  // Check for mixed memory spaces - raise error if mixed
-  if (M_is_device && (!v_is_device || !r_is_device)) {
-    fprintf(stderr, "Error in USpMv: Matrix is on device but vectors are on host\n");
-    exit(1);
-  }
-  if ((v_is_device || r_is_device) && !M_is_device) {
-    fprintf(stderr, "Error in USpMv: Vectors are on device but matrix is on host\n");
-    exit(1);
-  }
+  // Check if vectors are on different memory spaces
   if (v_is_device != r_is_device) {
     fprintf(stderr, "Error in USpMv: Input and output vectors are on different memory spaces\n");
     exit(1);
   }
 
-  if (M_is_device && v_is_device && r_is_device) {
+  // If vectors are on device, assume M is also on device (structure pointer)
+  // and we need to copy metadata from device first
+  if (v_is_device && r_is_device) {
+    // M is a device pointer - copy metadata to host
+    QOCOCscMatrix M_host;
+    CUDA_CHECK(cudaMemcpy(&M_host, M, sizeof(QOCOCscMatrix), cudaMemcpyDeviceToHost));
+    
     // All on device - use GPU kernel
     // First initialize result vector to zero
-    CUDA_CHECK(cudaMemset(r, 0, M->n * sizeof(QOCOFloat)));
+    CUDA_CHECK(cudaMemset(r, 0, M_host.n * sizeof(QOCOFloat)));
     // Launch kernel with one thread per column
-    USpMv_kernel<<<M->n, 1>>>(M, v, r);
+    USpMv_kernel<<<M_host.n, 1>>>(M, v, r);
     CUDA_CHECK(cudaDeviceSynchronize());
   }
   else {
+    // Vectors are on host - check if matrix data is on device
+    cudaPointerAttributes attrs_Mx, attrs_Mp, attrs_Mi;
+    cudaError_t err_Mx = cudaPointerGetAttributes(&attrs_Mx, M->x);
+    cudaError_t err_Mp = cudaPointerGetAttributes(&attrs_Mp, M->p);
+    cudaError_t err_Mi = cudaPointerGetAttributes(&attrs_Mi, M->i);
+
+    // Determine if matrix data is on device
+    int Mx_is_device = (err_Mx == cudaSuccess && attrs_Mx.type == cudaMemoryTypeDevice);
+    int Mp_is_device = (err_Mp == cudaSuccess && attrs_Mp.type == cudaMemoryTypeDevice);
+    int Mi_is_device = (err_Mi == cudaSuccess && attrs_Mi.type == cudaMemoryTypeDevice);
+    int M_is_device = Mx_is_device || Mp_is_device || Mi_is_device;
+
+    // Check for mixed memory spaces - raise error if mixed
+    if (M_is_device) {
+      fprintf(stderr, "Error in USpMv: Matrix is on device but vectors are on host\n");
+      exit(1);
+    }
+
     // All on host - use CPU implementation
     for (QOCOInt i = 0; i < M->n; i++) {
       r[i] = 0.0;
@@ -631,13 +687,63 @@ void SpMv(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r)
   qoco_assert(v);
   qoco_assert(r);
 
-  for (QOCOInt i = 0; i < M->m; ++i) {
-    r[i] = 0.0;
+  // Check if vector pointers are on device first
+  cudaPointerAttributes attrs_v, attrs_r;
+  cudaError_t err_v = cudaPointerGetAttributes(&attrs_v, v);
+  cudaError_t err_r = cudaPointerGetAttributes(&attrs_r, r);
+
+  // Determine if vectors are on device
+  int v_is_device = (err_v == cudaSuccess && attrs_v.type == cudaMemoryTypeDevice);
+  int r_is_device = (err_r == cudaSuccess && attrs_r.type == cudaMemoryTypeDevice);
+
+  // Check if vectors are on different memory spaces
+  if (v_is_device != r_is_device) {
+    fprintf(stderr, "Error in SpMv: Input and output vectors are on different memory spaces\n");
+    exit(1);
   }
 
-  for (QOCOInt j = 0; j < M->n; j++) {
-    for (QOCOInt i = M->p[j]; i < M->p[j + 1]; i++) {
-      r[M->i[i]] += M->x[i] * v[j];
+  // If vectors are on device, assume M is also on device (structure pointer)
+  // and we need to copy metadata from device first
+  if (v_is_device && r_is_device) {
+    // M is a device pointer - copy metadata to host
+    QOCOCscMatrix M_host;
+    CUDA_CHECK(cudaMemcpy(&M_host, M, sizeof(QOCOCscMatrix), cudaMemcpyDeviceToHost));
+    
+    // All on device - use GPU kernel
+    // First initialize result vector to zero
+    CUDA_CHECK(cudaMemset(r, 0, M_host.m * sizeof(QOCOFloat)));
+    // Launch kernel with one thread per column
+    SpMv_kernel<<<M_host.n, 1>>>(M, v, r);
+    CUDA_CHECK(cudaDeviceSynchronize());
+  }
+  else {
+    // Vectors are on host - check if matrix data is on device
+    cudaPointerAttributes attrs_Mx, attrs_Mp, attrs_Mi;
+    cudaError_t err_Mx = cudaPointerGetAttributes(&attrs_Mx, M->x);
+    cudaError_t err_Mp = cudaPointerGetAttributes(&attrs_Mp, M->p);
+    cudaError_t err_Mi = cudaPointerGetAttributes(&attrs_Mi, M->i);
+
+    // Determine if matrix data is on device
+    int Mx_is_device = (err_Mx == cudaSuccess && attrs_Mx.type == cudaMemoryTypeDevice);
+    int Mp_is_device = (err_Mp == cudaSuccess && attrs_Mp.type == cudaMemoryTypeDevice);
+    int Mi_is_device = (err_Mi == cudaSuccess && attrs_Mi.type == cudaMemoryTypeDevice);
+    int M_is_device = Mx_is_device || Mp_is_device || Mi_is_device;
+
+    // Check for mixed memory spaces - raise error if mixed
+    if (M_is_device) {
+      fprintf(stderr, "Error in SpMv: Matrix is on device but vectors are on host\n");
+      exit(1);
+    }
+
+    // All on host - use CPU implementation
+    for (QOCOInt i = 0; i < M->m; i++) {
+      r[i] = 0.0;
+    }
+    for (QOCOInt col = 0; col < M->n; col++) {
+      for (QOCOInt idx = M->p[col]; idx < M->p[col + 1]; idx++) {
+        QOCOInt row = M->i[idx];
+        r[row] += M->x[idx] * v[col];
+      }
     }
   }
 }
@@ -648,13 +754,63 @@ void SpMtv(const QOCOCscMatrix* M, const QOCOFloat* v, QOCOFloat* r)
   qoco_assert(v);
   qoco_assert(r);
 
-  for (QOCOInt i = 0; i < M->n; ++i) {
-    r[i] = 0.0;
+  // Check if vector pointers are on device first
+  cudaPointerAttributes attrs_v, attrs_r;
+  cudaError_t err_v = cudaPointerGetAttributes(&attrs_v, v);
+  cudaError_t err_r = cudaPointerGetAttributes(&attrs_r, r);
+
+  // Determine if vectors are on device
+  int v_is_device = (err_v == cudaSuccess && attrs_v.type == cudaMemoryTypeDevice);
+  int r_is_device = (err_r == cudaSuccess && attrs_r.type == cudaMemoryTypeDevice);
+
+  // Check if vectors are on different memory spaces
+  if (v_is_device != r_is_device) {
+    fprintf(stderr, "Error in SpMtv: Input and output vectors are on different memory spaces\n");
+    exit(1);
   }
 
-  for (QOCOInt i = 0; i < M->n; i++) {
-    for (QOCOInt j = M->p[i]; j < M->p[i + 1]; j++) {
-      r[i] += M->x[j] * v[M->i[j]];
+  // If vectors are on device, assume M is also on device (structure pointer)
+  // and we need to copy metadata from device first
+  if (v_is_device && r_is_device) {
+    // M is a device pointer - copy metadata to host
+    QOCOCscMatrix M_host;
+    CUDA_CHECK(cudaMemcpy(&M_host, M, sizeof(QOCOCscMatrix), cudaMemcpyDeviceToHost));
+    
+    // All on device - use GPU kernel
+    // First initialize result vector to zero
+    CUDA_CHECK(cudaMemset(r, 0, M_host.n * sizeof(QOCOFloat)));
+    // Launch kernel with one thread per column
+    SpMtv_kernel<<<M_host.n, 1>>>(M, v, r);
+    CUDA_CHECK(cudaDeviceSynchronize());
+  }
+  else {
+    // Vectors are on host - check if matrix data is on device
+    cudaPointerAttributes attrs_Mx, attrs_Mp, attrs_Mi;
+    cudaError_t err_Mx = cudaPointerGetAttributes(&attrs_Mx, M->x);
+    cudaError_t err_Mp = cudaPointerGetAttributes(&attrs_Mp, M->p);
+    cudaError_t err_Mi = cudaPointerGetAttributes(&attrs_Mi, M->i);
+
+    // Determine if matrix data is on device
+    int Mx_is_device = (err_Mx == cudaSuccess && attrs_Mx.type == cudaMemoryTypeDevice);
+    int Mp_is_device = (err_Mp == cudaSuccess && attrs_Mp.type == cudaMemoryTypeDevice);
+    int Mi_is_device = (err_Mi == cudaSuccess && attrs_Mi.type == cudaMemoryTypeDevice);
+    int M_is_device = Mx_is_device || Mp_is_device || Mi_is_device;
+
+    // Check for mixed memory spaces - raise error if mixed
+    if (M_is_device) {
+      fprintf(stderr, "Error in SpMtv: Matrix is on device but vectors are on host\n");
+      exit(1);
+    }
+
+    // All on host - use CPU implementation
+    for (QOCOInt i = 0; i < M->n; ++i) {
+      r[i] = 0.0;
+    }
+
+    for (QOCOInt i = 0; i < M->n; i++) {
+      for (QOCOInt j = M->p[i]; j < M->p[i + 1]; j++) {
+        r[i] += M->x[j] * v[M->i[j]];
+      }
     }
   }
 }
@@ -679,7 +835,7 @@ void USpMv_matrix(const QOCOMatrix* M, const QOCOFloat* v, QOCOFloat* r)
                       "This can happen if the matrix was created with A=NULL or if device allocation failed.\n");
       exit(1);
     }
-    // Use device matrix - d_csc->x, d_csc->p, d_csc->i are device pointers
+    // Use device matrix structure - pass device pointer to structure
     USpMv(M->d_csc, v, r);
   }
   else if (!v_is_device && !r_is_device) {
@@ -696,12 +852,70 @@ void USpMv_matrix(const QOCOMatrix* M, const QOCOFloat* v, QOCOFloat* r)
 
 void SpMv_matrix(const QOCOMatrix* M, const QOCOFloat* v, QOCOFloat* r)
 {
-  SpMv(M->csc, v, r);
+  // Check if vectors are on device
+  cudaPointerAttributes attrs_v, attrs_r;
+  cudaError_t err_v = cudaPointerGetAttributes(&attrs_v, v);
+  cudaError_t err_r = cudaPointerGetAttributes(&attrs_r, r);
+
+  // If cudaPointerGetAttributes fails, assume host pointer
+  int v_is_device = (err_v == cudaSuccess && attrs_v.type == cudaMemoryTypeDevice);
+  int r_is_device = (err_r == cudaSuccess && attrs_r.type == cudaMemoryTypeDevice);
+
+  // Use device matrix only if BOTH vectors are on device and device matrix exists
+  if (v_is_device && r_is_device) {
+    if (!M->d_csc) {
+      fprintf(stderr, "Error in SpMv_matrix: Vectors are on device but device matrix (d_csc) is NULL. "
+                      "Matrix was likely created without device allocation. "
+                      "This can happen if the matrix was created with A=NULL or if device allocation failed.\n");
+      exit(1);
+    }
+    // Use device matrix structure - pass device pointer to structure
+    SpMv(M->d_csc, v, r);
+  }
+  else if (!v_is_device && !r_is_device) {
+    // Both vectors on host, use host matrix
+    SpMv(M->csc, v, r);
+  }
+  else {
+    // Mixed: one vector on device, one on host - this is an error
+    fprintf(stderr, "Error in SpMv_matrix: Input and output vectors are on different memory spaces. "
+                    "v_is_device=%d, r_is_device=%d\n", v_is_device, r_is_device);
+    exit(1);
+  }
 }
 
 void SpMtv_matrix(const QOCOMatrix* M, const QOCOFloat* v, QOCOFloat* r)
 {
-  SpMtv(M->csc, v, r);
+  // Check if vectors are on device
+  cudaPointerAttributes attrs_v, attrs_r;
+  cudaError_t err_v = cudaPointerGetAttributes(&attrs_v, v);
+  cudaError_t err_r = cudaPointerGetAttributes(&attrs_r, r);
+
+  // If cudaPointerGetAttributes fails, assume host pointer
+  int v_is_device = (err_v == cudaSuccess && attrs_v.type == cudaMemoryTypeDevice);
+  int r_is_device = (err_r == cudaSuccess && attrs_r.type == cudaMemoryTypeDevice);
+
+  // Use device matrix only if BOTH vectors are on device and device matrix exists
+  if (v_is_device && r_is_device) {
+    if (!M->d_csc) {
+      fprintf(stderr, "Error in SpMtv_matrix: Vectors are on device but device matrix (d_csc) is NULL. "
+                      "Matrix was likely created without device allocation. "
+                      "This can happen if the matrix was created with A=NULL or if device allocation failed.\n");
+      exit(1);
+    }
+    // Use device matrix structure - pass device pointer to structure
+    SpMtv(M->d_csc, v, r);
+  }
+  else if (!v_is_device && !r_is_device) {
+    // Both vectors on host, use host matrix
+    SpMtv(M->csc, v, r);
+  }
+  else {
+    // Mixed: one vector on device, one on host - this is an error
+    fprintf(stderr, "Error in SpMtv_matrix: Input and output vectors are on different memory spaces. "
+                    "v_is_device=%d, r_is_device=%d\n", v_is_device, r_is_device);
+    exit(1);
+  }
 }
 
 QOCOFloat inf_norm(const QOCOFloat* x, QOCOInt n)

--- a/algebra/cuda/cuda_linalg.cu
+++ b/algebra/cuda/cuda_linalg.cu
@@ -166,14 +166,23 @@ QOCOFloat* get_pointer_vectorf(const QOCOVectorf* x, QOCOInt idx)
   return &x->data[idx];
 }
 
+// Static flag to track when we're in compute_scaling_statistics
+static int in_scaling_statistics_mode = 0;
+
+void set_scaling_statistics_mode(int active)
+{
+  in_scaling_statistics_mode = active;
+}
+
 QOCOFloat* get_data_vectorf(const QOCOVectorf* x)
 {
+  // During compute_scaling_statistics, return host pointer for CPU access
+  if (in_scaling_statistics_mode) {
+    return x->data;
+  }
   // During equilibration/setup (CPU phase), return host pointer
   // During solve (GPU phase), return device pointer to avoid CPU-GPU copies
-  // if (x->d_data) {
-  //   return x->d_data;
-  // }
-  return x->data;
+  return x->d_data;
 }
 
 QOCOInt get_length_vectorf(const QOCOVectorf* x) { return x->len; }

--- a/algebra/cuda/cuda_types.h
+++ b/algebra/cuda/cuda_types.h
@@ -36,7 +36,8 @@ struct QOCOVectorf_ {
 };
 
 struct QOCOMatrix_ {
-  QOCOCscMatrix* csc;
+  QOCOCscMatrix* csc;      // Host CSC matrix
+  QOCOCscMatrix* d_csc;    // Device CSC matrix (NULL if not allocated)
 };
 
 #endif /* ifndef CUDA_TYPES_H */

--- a/algebra/cuda/cuda_types.h
+++ b/algebra/cuda/cuda_types.h
@@ -37,7 +37,7 @@ struct QOCOVectorf_ {
 
 struct QOCOMatrix_ {
   QOCOCscMatrix* csc;      // Host CSC matrix
-  QOCOCscMatrix* d_csc;    // Device CSC matrix (NULL if not allocated)
+  QOCOCscMatrix* d_csc;    // Device pointer to device CSC matrix structure
 };
 
 #endif /* ifndef CUDA_TYPES_H */

--- a/algebra/cuda/cuda_types.h
+++ b/algebra/cuda/cuda_types.h
@@ -16,11 +16,15 @@
 #ifndef CUDA_TYPES_H
 #define CUDA_TYPES_H
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 #include "common_linalg.h"
 #include "definitions.h"
 #include "qoco_linalg.h"
+#ifdef __cplusplus
 }
+#endif
 #include <cuda_runtime.h>
 
 struct QOCOVectori_ {

--- a/devtools/run_tests_gpu.sh
+++ b/devtools/run_tests_gpu.sh
@@ -1,1 +1,1 @@
-export CXX=/usr/bin/clang++ && export CC=/usr/bin/clang && cd build && cmake -DQOCO_BUILD_TYPE:STR=Release -DENABLE_TESTING:BOOL=True -DBUILD_QOCO_BENCHMARK_RUNNER:BOOL=True -DQOCO_ALGEBRA_BACKEND:str="cuda" .. && make -j$(nproc) && ctest --verbose && cd ..
+export CXX=/usr/bin/clang++ && export CC=/usr/bin/clang && cd build && cmake -DQOCO_BUILD_TYPE:STR=Release -DENABLE_TESTING:BOOL=True -DBUILD_QOCO_BENCHMARK_RUNNER:BOOL=True -DQOCO_ALGEBRA_BACKEND:str="cuda" -DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.0/bin/nvcc .. && make -j$(nproc) && ctest --verbose && cd ..

--- a/include/common_linalg.h
+++ b/include/common_linalg.h
@@ -104,16 +104,6 @@ QOCOCscMatrix* create_transposed_matrix(const QOCOCscMatrix* A, QOCOInt* AtoAt);
 void row_col_scale(const QOCOCscMatrix* M, QOCOFloat* E, QOCOFloat* D);
 
 /**
- * @brief Computes elementwise product z = x .* y
- *
- * @param x Input array.
- * @param y Input array.
- * @param z Output array.
- * @param n Length of arrays.
- */
-void ew_product(QOCOFloat* x, const QOCOFloat* y, QOCOFloat* z, QOCOInt n);
-
-/**
  * @brief Inverts permutation vector p and stores inverse in pinv.
  *
  * @param p Input permutation vector.

--- a/include/qoco_linalg.h
+++ b/include/qoco_linalg.h
@@ -154,6 +154,15 @@ void sync_vector_to_host(QOCOVectorf* v);
 void set_solve_phase(int active);
 
 /**
+ * @brief Sets the scaling statistics mode flag (CUDA backend only).
+ * During scaling statistics computation, get_data_vectorf returns host pointers.
+ * This allows CPU access to vector data for statistics computation.
+ *
+ * @param active 1 if scaling statistics mode is active, 0 otherwise.
+ */
+void set_scaling_statistics_mode(int active);
+
+/**
  * @brief Returns the length of a QOCOVectorf.
  *
  * @param x Input vector.

--- a/include/qoco_linalg.h
+++ b/include/qoco_linalg.h
@@ -20,6 +20,8 @@ typedef struct QOCOMatrix_ QOCOMatrix;
 typedef struct QOCOVectorf_ QOCOVectorf;
 typedef struct QOCOVectori_ QOCOVectori;
 
+void ew_product(QOCOFloat* x, const QOCOFloat* y, QOCOFloat* z, QOCOInt n);
+
 /**
  * @brief Compressed sparse column format matrices.
  *
@@ -143,6 +145,7 @@ QOCOFloat* get_data_vectorf(const QOCOVectorf* x);
  * @param v Input vector.
  */
 void sync_vector_to_host(QOCOVectorf* v);
+void sync_vector_to_device(const QOCOVectorf* v);
 
 /**
  * @brief Sets the solve phase flag (CUDA backend only).

--- a/include/qoco_utils.h
+++ b/include/qoco_utils.h
@@ -37,6 +37,10 @@ void print_qoco_csc_matrix(QOCOCscMatrix* M);
  * @param n Number of elements in array.
  */
 void print_arrayf(QOCOFloat* x, QOCOInt n);
+/**
+ * @brief Syncs a vector to host and prints its contents.
+ */
+void print_vectorf(const QOCOVectorf* v);
 
 /**
  * @brief Prints array of QOCOInts.

--- a/include/structs.h
+++ b/include/structs.h
@@ -263,13 +263,13 @@ typedef struct {
   QOCOVectorf* xyz;
 
   /** Buffer of size n + m + p. */
-  QOCOFloat* xyzbuff1;
+  QOCOVectorf* xyzbuff1;
 
   /** Buffer of size n + m + p. */
-  QOCOFloat* xyzbuff2;
+  QOCOVectorf* xyzbuff2;
 
   /** Residual of KKT condition. */
-  QOCOFloat* kktres;
+  QOCOVectorf* kktres;
 
 } QOCOWorkspace;
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -239,7 +239,7 @@ typedef struct {
   QOCOFloat* zbar;
 
   /** Temporary variable of length n. */
-  QOCOFloat* xbuff;
+  QOCOVectorf* xbuff;
 
   /** Temporary variable of length p. */
   QOCOFloat* ybuff;

--- a/include/structs.h
+++ b/include/structs.h
@@ -242,16 +242,16 @@ typedef struct {
   QOCOVectorf* xbuff;
 
   /** Temporary variable of length p. */
-  QOCOFloat* ybuff;
+  QOCOVectorf* ybuff;
 
   /** Temporary variable of length m. */
-  QOCOFloat* ubuff1;
+  QOCOVectorf* ubuff1;
 
   /** Temporary variable of length m. */
-  QOCOFloat* ubuff2;
+  QOCOVectorf* ubuff2;
 
   /** Temporary variable of length m. */
-  QOCOFloat* ubuff3;
+  QOCOVectorf* ubuff3;
 
   /** Search direction for slack variables. Length of m. */
   QOCOFloat* Ds;

--- a/src/common_linalg.c
+++ b/src/common_linalg.c
@@ -238,12 +238,14 @@ void row_col_scale(const QOCOCscMatrix* M, QOCOFloat* E, QOCOFloat* D)
   }
 }
 
+#ifndef QOCO_ALGEBRA_BACKEND_CUDA
 void ew_product(QOCOFloat* x, const QOCOFloat* y, QOCOFloat* z, QOCOInt n)
 {
   for (QOCOInt i = 0; i < n; ++i) {
     z[i] = x[i] * y[i];
   }
 }
+#endif
 
 void invert_permutation(const QOCOInt* p, QOCOInt* pinv, QOCOInt n)
 {

--- a/src/equilibration.c
+++ b/src/equilibration.c
@@ -3,6 +3,9 @@
 void ruiz_equilibration(QOCOProblemData* data, QOCOScaling* scaling,
                         QOCOInt ruiz_iters)
 {
+  // Enable host data mode for CUDA backend (no-op for builtin backend)
+  set_scaling_statistics_mode(1);
+
   // Initialize ruiz data.
   for (QOCOInt i = 0; i < data->n; ++i) {
     set_element_vectorf(scaling->Druiz, i, 1.0);
@@ -154,6 +157,9 @@ void ruiz_equilibration(QOCOProblemData* data, QOCOScaling* scaling,
   reciprocal_vectorf(scaling->Eruiz, scaling->Einvruiz);
   reciprocal_vectorf(scaling->Fruiz, scaling->Finvruiz);
   scaling->kinv = safe_div(1.0, scaling->k);
+
+  // Disable host data mode for CUDA backend (no-op for builtin backend)
+  set_scaling_statistics_mode(0);
 }
 
 void unscale_variables(QOCOWorkspace* work)

--- a/src/equilibration.c
+++ b/src/equilibration.c
@@ -160,6 +160,17 @@ void ruiz_equilibration(QOCOProblemData* data, QOCOScaling* scaling,
 
   // Disable host data mode for CUDA backend (no-op for builtin backend)
   set_scaling_statistics_mode(0);
+
+  // Sync updated scaling vectors and scaled data to device (CUDA backend).
+  sync_vector_to_device(scaling->Druiz);
+  sync_vector_to_device(scaling->Eruiz);
+  sync_vector_to_device(scaling->Fruiz);
+  sync_vector_to_device(scaling->Dinvruiz);
+  sync_vector_to_device(scaling->Einvruiz);
+  sync_vector_to_device(scaling->Finvruiz);
+  sync_vector_to_device(data->c);
+  sync_vector_to_device(data->b);
+  sync_vector_to_device(data->h);
 }
 
 void unscale_variables(QOCOWorkspace* work)

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -287,7 +287,7 @@ void construct_kkt_aff_rhs(QOCOWorkspace* work)
   QOCOFloat* rhs = get_data_vectorf(work->rhs);
 
   // Negate the kkt residual and store in rhs.
-  copy_and_negate_arrayf(work->kktres, rhs,
+  copy_and_negate_arrayf(get_data_vectorf(work->kktres), rhs,
                          work->data->n + work->data->p + work->data->m);
 
   // Compute W*lambda
@@ -305,7 +305,7 @@ void construct_kkt_comb_rhs(QOCOWorkspace* work)
   QOCOFloat* xyz = get_data_vectorf(work->xyz);
 
   // Negate the kkt residual and store in rhs.
-  copy_and_negate_arrayf(work->kktres, rhs,
+  copy_and_negate_arrayf(get_data_vectorf(work->kktres), rhs,
                          work->data->n + work->data->p + work->data->m);
 
   /// ds = -cone_product(lambda, lambda) - settings.mehrotra *

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -226,10 +226,13 @@ void initialize_ipm(QOCOSolver* solver)
                          solver->work->data->m);
 
   // Bring s and z to cone C.
+  // TODO: bring2cone should be called on the device to avoid CPU-GPU copies.
   set_scaling_statistics_mode(1);
   bring2cone(get_data_vectorf(solver->work->s), solver->work->data);
   bring2cone(get_data_vectorf(solver->work->z), solver->work->data);
   set_scaling_statistics_mode(0);
+  sync_vector_to_device(solver->work->s); 
+  sync_vector_to_device(solver->work->z);
 }
 
 void compute_kkt_residual(QOCOProblemData* data, QOCOFloat* x, QOCOFloat* y,

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -226,8 +226,10 @@ void initialize_ipm(QOCOSolver* solver)
                          solver->work->data->m);
 
   // Bring s and z to cone C.
+  set_scaling_statistics_mode(1);
   bring2cone(get_data_vectorf(solver->work->s), solver->work->data);
   bring2cone(get_data_vectorf(solver->work->z), solver->work->data);
+  set_scaling_statistics_mode(0);
 }
 
 void compute_kkt_residual(QOCOProblemData* data, QOCOFloat* x, QOCOFloat* y,

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -171,10 +171,10 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   solver->work->ubuff3 = qoco_malloc(m * sizeof(QOCOFloat));
   solver->work->Ds = qoco_malloc(m * sizeof(QOCOFloat));
   solver->work->rhs = new_qoco_vectorf(NULL, n + m + p);
-  solver->work->kktres = qoco_malloc((n + m + p) * sizeof(QOCOFloat));
+  solver->work->kktres = new_qoco_vectorf(NULL, n + m + p);
   solver->work->xyz = new_qoco_vectorf(NULL, n + m + p);
-  solver->work->xyzbuff1 = qoco_malloc((n + m + p) * sizeof(QOCOFloat));
-  solver->work->xyzbuff2 = qoco_malloc((n + m + p) * sizeof(QOCOFloat));
+  solver->work->xyzbuff1 = new_qoco_vectorf(NULL, n + m + p);
+  solver->work->xyzbuff2 = new_qoco_vectorf(NULL, n + m + p);
 
   // Allocate solution struct.
   solver->sol = qoco_malloc(sizeof(QOCOSolution));
@@ -400,8 +400,8 @@ QOCOInt qoco_solve(QOCOSolver* solver)
     // Compute kkt residual.
     compute_kkt_residual(data, get_data_vectorf(work->x),
                          get_data_vectorf(work->y), get_data_vectorf(work->s),
-                         get_data_vectorf(work->z), work->kktres,
-                         solver->settings->kkt_static_reg, work->xyzbuff1,
+                         get_data_vectorf(work->z), get_data_vectorf(work->kktres),
+                         solver->settings->kkt_static_reg, get_data_vectorf(work->xyzbuff1),
                          work->xbuff, work->ubuff1, work->ubuff2);
 
     // Compute objective function.
@@ -480,10 +480,10 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
 
   // Free primal and dual variables.
   free_qoco_vectorf(solver->work->rhs);
-  qoco_free(solver->work->kktres);
+  free_qoco_vectorf(solver->work->kktres);
   free_qoco_vectorf(solver->work->xyz);
-  qoco_free(solver->work->xyzbuff1);
-  qoco_free(solver->work->xyzbuff2);
+  free_qoco_vectorf(solver->work->xyzbuff1);
+  free_qoco_vectorf(solver->work->xyzbuff2);
   free_qoco_vectorf(solver->work->x);
   free_qoco_vectorf(solver->work->s);
   free_qoco_vectorf(solver->work->y);

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -164,7 +164,7 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   }
   solver->work->sbar = qoco_malloc(qmax * sizeof(QOCOFloat));
   solver->work->zbar = qoco_malloc(qmax * sizeof(QOCOFloat));
-  solver->work->xbuff = qoco_malloc(n * sizeof(QOCOFloat));
+  solver->work->xbuff = new_qoco_vectorf(NULL, n);
   solver->work->ybuff = qoco_malloc(p * sizeof(QOCOFloat));
   solver->work->ubuff1 = qoco_malloc(m * sizeof(QOCOFloat));
   solver->work->ubuff2 = qoco_malloc(m * sizeof(QOCOFloat));
@@ -402,11 +402,11 @@ QOCOInt qoco_solve(QOCOSolver* solver)
                          get_data_vectorf(work->y), get_data_vectorf(work->s),
                          get_data_vectorf(work->z), get_data_vectorf(work->kktres),
                          solver->settings->kkt_static_reg, get_data_vectorf(work->xyzbuff1),
-                         work->xbuff, work->ubuff1, work->ubuff2);
+                         get_data_vectorf(work->xbuff), work->ubuff1, work->ubuff2);
 
     // Compute objective function.
     solver->sol->obj =
-        compute_objective(data, get_data_vectorf(work->x), work->xbuff,
+        compute_objective(data, get_data_vectorf(work->x), get_data_vectorf(work->xbuff),
                           solver->settings->kkt_static_reg, work->scaling->k);
 
     // Compute mu = s'*z / m.
@@ -498,7 +498,7 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
   qoco_free(solver->work->lambda);
   qoco_free(solver->work->sbar);
   qoco_free(solver->work->zbar);
-  qoco_free(solver->work->xbuff);
+  free_qoco_vectorf(solver->work->xbuff);
   qoco_free(solver->work->ybuff);
   qoco_free(solver->work->ubuff1);
   qoco_free(solver->work->ubuff2);

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -393,12 +393,6 @@ QOCOInt qoco_solve(QOCOSolver* solver)
     print_header(solver);
   }
 
-// Set solve phase flag for CUDA backend (prevents get_data_vectorf from
-// returning device pointers)
-#ifdef QOCO_ALGEBRA_BACKEND_CUDA
-  set_solve_phase(1);
-#endif
-
   // Get initializations for primal and dual variables.
   initialize_ipm(solver);
   for (QOCOInt i = 1; i <= solver->settings->max_iters; ++i) {

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -435,6 +435,7 @@ QOCOInt qoco_solve(QOCOSolver* solver)
     // Update Nestrov-Todd block of KKT matrix.
     solver->linsys->linsys_update_nt(solver->linsys_data, work->WtW,
                                      solver->settings->kkt_static_reg, data->m);
+    exit(1);
 
     // Perform predictor-corrector.
     predictor_corrector(solver);

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -165,10 +165,10 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   solver->work->sbar = qoco_malloc(qmax * sizeof(QOCOFloat));
   solver->work->zbar = qoco_malloc(qmax * sizeof(QOCOFloat));
   solver->work->xbuff = new_qoco_vectorf(NULL, n);
-  solver->work->ybuff = qoco_malloc(p * sizeof(QOCOFloat));
-  solver->work->ubuff1 = qoco_malloc(m * sizeof(QOCOFloat));
-  solver->work->ubuff2 = qoco_malloc(m * sizeof(QOCOFloat));
-  solver->work->ubuff3 = qoco_malloc(m * sizeof(QOCOFloat));
+  solver->work->ybuff = new_qoco_vectorf(NULL, p);
+  solver->work->ubuff1 = new_qoco_vectorf(NULL, m);
+  solver->work->ubuff2 = new_qoco_vectorf(NULL, m);
+  solver->work->ubuff3 = new_qoco_vectorf(NULL, m);
   solver->work->Ds = qoco_malloc(m * sizeof(QOCOFloat));
   solver->work->rhs = new_qoco_vectorf(NULL, n + m + p);
   solver->work->kktres = new_qoco_vectorf(NULL, n + m + p);
@@ -402,7 +402,9 @@ QOCOInt qoco_solve(QOCOSolver* solver)
                          get_data_vectorf(work->y), get_data_vectorf(work->s),
                          get_data_vectorf(work->z), get_data_vectorf(work->kktres),
                          solver->settings->kkt_static_reg, get_data_vectorf(work->xyzbuff1),
-                         get_data_vectorf(work->xbuff), work->ubuff1, work->ubuff2);
+                         get_data_vectorf(work->xbuff),
+                         get_data_vectorf(work->ubuff1),
+                         get_data_vectorf(work->ubuff2));
 
     // Compute objective function.
     solver->sol->obj =
@@ -499,10 +501,10 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
   qoco_free(solver->work->sbar);
   qoco_free(solver->work->zbar);
   free_qoco_vectorf(solver->work->xbuff);
-  qoco_free(solver->work->ybuff);
-  qoco_free(solver->work->ubuff1);
-  qoco_free(solver->work->ubuff2);
-  qoco_free(solver->work->ubuff3);
+  free_qoco_vectorf(solver->work->ybuff);
+  free_qoco_vectorf(solver->work->ubuff1);
+  free_qoco_vectorf(solver->work->ubuff2);
+  free_qoco_vectorf(solver->work->ubuff3);
   qoco_free(solver->work->Ds);
 
   // Free scaling struct.

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -70,6 +70,9 @@ void print_arrayi(QOCOInt* x, QOCOInt n)
 
 void compute_scaling_statistics(QOCOProblemData* data)
 {
+  // Enable host data mode for CUDA backend (no-op for builtin backend)
+  set_scaling_statistics_mode(1);
+
   // Initialize min/max values
   data->obj_range_min = QOCOFloat_MAX;
   data->obj_range_max = 0.0;
@@ -149,6 +152,9 @@ void compute_scaling_statistics(QOCOProblemData* data)
   if (data->rhs_range_min == QOCOFloat_MAX || data->rhs_range_min == 0.0) {
     data->rhs_range_min = 0.0;
   }
+
+  // Disable host data mode for CUDA backend (no-op for builtin backend)
+  set_scaling_statistics_mode(0);
 }
 
 void print_header(QOCOSolver* solver)

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -281,10 +281,11 @@ unsigned char check_stopping(QOCOSolver* solver)
   QOCOFloat Gxinf = data->m ? inf_norm(work->ubuff1, data->m) : 0;
 
   // Compute primal residual.
-  ew_product(&work->kktres[data->n], Einvruiz_data, work->ybuff, data->p);
+  QOCOFloat* kktres_data = get_data_vectorf(work->kktres);
+  ew_product(&kktres_data[data->n], Einvruiz_data, work->ybuff, data->p);
   QOCOFloat eq_res = inf_norm(work->ybuff, data->p);
 
-  ew_product(&work->kktres[data->n + data->p], Finvruiz_data, work->ubuff1,
+  ew_product(&kktres_data[data->n + data->p], Finvruiz_data, work->ubuff1,
              data->m);
   QOCOFloat conic_res = inf_norm(work->ubuff1, data->m);
 
@@ -292,7 +293,7 @@ unsigned char check_stopping(QOCOSolver* solver)
   solver->sol->pres = pres;
 
   // Compute dual residual.
-  ew_product(work->kktres, Dinvruiz_data, work->xbuff, data->n);
+  ew_product(kktres_data, Dinvruiz_data, work->xbuff, data->n);
   scale_arrayf(work->xbuff, work->xbuff, work->scaling->kinv, data->n);
   QOCOFloat dres = inf_norm(work->xbuff, data->n);
   solver->sol->dres = dres;

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -68,6 +68,20 @@ void print_arrayi(QOCOInt* x, QOCOInt n)
   printf("}\n");
 }
 
+void print_vectorf(const QOCOVectorf* v)
+{
+  if (!v) {
+    printf("vector is NULL\n");
+    return;
+  }
+  // Ensure host data is up to date (no-op on CPU backend)
+  sync_vector_to_host((QOCOVectorf*)v);
+  // Use host pointer via get_pointer_vectorf to avoid device pointer
+  QOCOFloat* data = get_pointer_vectorf(v, 0);
+  QOCOInt len = get_length_vectorf(v);
+  print_arrayf(data, len);
+}
+
 void compute_scaling_statistics(QOCOProblemData* data)
 {
   // Enable host data mode for CUDA backend (no-op for builtin backend)
@@ -309,7 +323,7 @@ unsigned char check_stopping(QOCOSolver* solver)
   solver->sol->gap = gap;
 
   // Compute max{Axinf, binf, Gxinf, hinf, sinf}.
-  QOCOFloat pres_rel = qoco_max(Axinf, binf);
+  QOCOFloat pres_rel = qoco_max(Axinf, 0);
   pres_rel = qoco_max(pres_rel, Gxinf);
   pres_rel = qoco_max(pres_rel, hinf);
   pres_rel = qoco_max(pres_rel, sinf);

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -267,9 +267,7 @@ unsigned char check_stopping(QOCOSolver* solver)
 
   // Compute ||P * x||_\infty
   USpMv_matrix(data->P, xdata, xbuff_data);
-  for (QOCOInt i = 0; i < data->n; ++i) {
-    xbuff_data[i] -= solver->settings->kkt_static_reg * xdata[i];
-  }
+  qoco_axpy(xdata, xbuff_data, xbuff_data, -solver->settings->kkt_static_reg, data->n);
   ew_product(xbuff_data, Dinvruiz_data, xbuff_data, data->n);
   QOCOFloat Pxinf = inf_norm(xbuff_data, data->n);
   QOCOFloat xPx = qoco_dot(xdata, xbuff_data, work->data->n);
@@ -343,17 +341,22 @@ unsigned char check_stopping(QOCOSolver* solver)
         dres < eabsinacc + erelinacc * dres_rel &&
         solver->sol->gap < eabsinacc + erelinacc * gap_rel) {
       solver->sol->status = QOCO_SOLVED_INACCURATE;
+      printf("stalled\n");
       return 1;
     }
     else {
       solver->sol->status = QOCO_NUMERICAL_ERROR;
+      printf("numerical error\n");
       return 1;
     }
   }
-
+  printf("pres: %f, pres_rel: %f, eabs: %f, erel: %f\n", pres, pres_rel, eabs, erel);
+  printf("dres: %f, dres_rel: %f, eabsinacc: %f, erelinacc: %f\n", dres, dres_rel, eabsinacc, erelinacc);
+  printf("solver->sol->gap: %f, gap_rel: %f, eabsinacc: %f, erelinacc: %f\n", solver->sol->gap, gap_rel, eabsinacc, erelinacc);
   if (pres < eabs + erel * pres_rel && dres < eabs + erel * dres_rel &&
       solver->sol->gap < eabs + erel * gap_rel) {
     solver->sol->status = QOCO_SOLVED;
+    printf("solved inaccurately\n");
     return 1;
   }
   return 0;


### PR DESCRIPTION
Currently, only the factorization and solves are performed on the GPU. All other operations are done on the CPU. This incurs significant overhead due to `cudaMemcpy`, so this PR seeks to remove all `cudaMemcpy`.

Track down all `get_data_vectorf()` calls. These should ideally return GPU pointers, but currently just returns CPU pointers. 

Then write kernels to operate directly on `QOCOVectorf` rather than directly accessing pointers in memory.

The main code for QOCO should not touch pointers at all and should just use the QOCOVectorf abstraction.