### PR TITLE
Set WtW block of KKT matrix to -I in `initialize_ipm`

### DIFF
--- a/algebra/builtin/qdldl_backend.c
+++ b/algebra/builtin/qdldl_backend.c
@@ -239,6 +239,17 @@ static void qdldl_solve(LinSysData* linsys_data, QOCOWorkspace* work,
   }
 }
 
+static void qdldl_set_nt_identity(LinSysData* linsys_data, QOCOInt m)
+{
+  for (QOCOInt i = 0; i < linsys_data->Wnnz; ++i) {
+    linsys_data->K->x[linsys_data->nt2kkt[i]] = 0;
+  }
+
+  for (QOCOInt i = 0; i < m; ++i) {
+    linsys_data->K->x[linsys_data->ntdiag2kkt[i]] = -1.0;
+  }
+}
+
 static void qdldl_update_nt(LinSysData* linsys_data, QOCOVectorf* WtW_vec,
                             QOCOFloat kkt_static_reg, QOCOInt m)
 {
@@ -306,6 +317,7 @@ static const char* qdldl_name() { return "builtin/qdldl"; }
 // Export the backend struct
 LinSysBackend backend = {.linsys_name = qdldl_name,
                          .linsys_setup = qdldl_setup,
+                         .linsys_set_nt_identity = qdldl_set_nt_identity,
                          .linsys_update_nt = qdldl_update_nt,
                          .linsys_update_data = qdldl_update_data,
                          .linsys_factor = qdldl_factor,

--- a/algebra/cuda/cudss_backend.cu
+++ b/algebra/cuda/cudss_backend.cu
@@ -684,7 +684,7 @@ static void cudss_solve(LinSysData* linsys_data, QOCOWorkspace* work,
                         cudaMemcpyDeviceToDevice));
 }
 
-void cudss_set_nt_identity_gpu(LinSysData* linsys_data, QOCOInt m)
+void cudss_set_nt_identity(LinSysData* linsys_data, QOCOInt m)
 {
   int Wnnz = linsys_data->Wnnz;
 

--- a/algebra/cuda/cudss_backend.cu
+++ b/algebra/cuda/cudss_backend.cu
@@ -617,6 +617,20 @@ update_csr_nt_diag_kernel(QOCOFloat* csr_val, // CSR values to update (on GPU)
   }
 }
 
+__global__ void set_nt_identity_kernel(double* Kx, const int* nt2kkt,
+                                       const int* ntdiag2kkt, int Wnnz, int m)
+{
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (tid < Wnnz) {
+    Kx[nt2kkt[tid]] = 0.0;
+  }
+
+  if (tid < m) {
+    Kx[ntdiag2kkt[tid]] = -1.0;
+  }
+}
+
 // CUDA kernel to update CSR values for P, A, G matrices
 __global__ void update_csr_matrix_data_kernel(
     const QOCOFloat* matrix_val, // New matrix values (on GPU)
@@ -668,6 +682,19 @@ static void cudss_solve(LinSysData* linsys_data, QOCOWorkspace* work,
   CUDA_CHECK(cudaMemcpy(x, linsys_data->d_xyz_matrix_data,
                         linsys_data->Kn * sizeof(QOCOFloat),
                         cudaMemcpyDeviceToDevice));
+}
+
+void cudss_set_nt_identity_gpu(LinSysData* linsys_data, QOCOInt m)
+{
+  int Wnnz = linsys_data->Wnnz;
+
+  int N = max(Wnnz, m);
+  int blockSize = 256;
+  int gridSize = (N + blockSize - 1) / blockSize;
+
+  set_nt_identity_kernel<<<gridSize, blockSize>>>(
+      linsys_data->d_csr_val, linsys_data->d_nt2kktcsr,
+      linsys_data->d_ntdiag2kktcsr, Wnnz, m);
 }
 
 static void cudss_update_nt(LinSysData* linsys_data, QOCOVectorf* WtW_vec,
@@ -782,6 +809,7 @@ static const char* cudss_name() { return "cuda/cuDSS"; }
 
 LinSysBackend backend = {.linsys_name = cudss_name,
                          .linsys_setup = cudss_setup,
+                         .linsys_set_nt_identity = cudss_set_nt_identity,
                          .linsys_update_nt = cudss_update_nt,
                          .linsys_update_data = cudss_update_data,
                          .linsys_factor = cudss_factor,

--- a/examples/qoco_demo.c
+++ b/examples/qoco_demo.c
@@ -53,11 +53,8 @@ int main()
   // Solve problem.
   if (exit == QOCO_NO_ERROR) {
     exit = qoco_solve(solver);
+    // update_matrix_data(solver, Px, Ax, Gx);
+    // update_vector_data(solver, c, b, h);
+    exit = qoco_solve(solver);
   }
-
-  // Free allocated memory.
-  qoco_cleanup(solver);
-  free(P);
-  free(A);
-  free(G);
 }

--- a/examples/qoco_demo.c
+++ b/examples/qoco_demo.c
@@ -53,8 +53,11 @@ int main()
   // Solve problem.
   if (exit == QOCO_NO_ERROR) {
     exit = qoco_solve(solver);
-    // update_matrix_data(solver, Px, Ax, Gx);
-    // update_vector_data(solver, c, b, h);
-    exit = qoco_solve(solver);
   }
+
+  // Free allocated memory.
+  qoco_cleanup(solver);
+  free(P);
+  free(A);
+  free(G);
 }

--- a/include/structs.h
+++ b/include/structs.h
@@ -328,6 +328,7 @@ typedef struct {
   const char* (*linsys_name)();
   LinSysData* (*linsys_setup)(QOCOProblemData* data, QOCOSettings* settings,
                               QOCOInt Wnnz);
+  void (*linsys_set_nt_identity)(LinSysData* linsys_data, QOCOInt m);
   void (*linsys_update_nt)(LinSysData* linsys_data, QOCOVectorf* WtW_vec,
                            QOCOFloat kkt_static_reg, QOCOInt m);
   void (*linsys_update_data)(LinSysData* linsys_data, QOCOProblemData* data);

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -169,6 +169,7 @@ void initialize_ipm(QOCOSolver* solver)
   // Set Nesterov-Todd block in Wfull to -I (need for kkt_multiply in iterative
   // refinement).
   set_Wfull_identity(work->Wfull, work->Wnnzfull, work->Wsoc_idx, data);
+  solver->linsys->linsys_set_nt_identity(solver->linsys_data, data->m);
 
   // Needs to be set to 1.0 not 0.0 due to low tolerance stopping criteria
   // checks which only occur when a = 0.0. If a is set to 0.0 then the low


### PR DESCRIPTION
When qoco currently solves a problem and then `qoco_solve` is called again, the KKT system contains the NT scaling from the final iteration of the first solve. Since the NT block of the KKT matrix is not reset, this leads to the behavior seen here: https://github.com/qoco-org/qoco/issues/45.

This fix sets the NT block to -I in `initialize_ipm` which fixes this issue.