### PR TITLE
Add closed-form SOC step-size computation

### DIFF
--- a/benchmarks/benchmark_runner.c
+++ b/benchmarks/benchmark_runner.c
@@ -16,9 +16,6 @@ static void apply_setting(QOCOSettings* settings, const char* arg)
   if (strcmp(key, "max_iters") == 0) {
     settings->max_iters = atoi(val);
   }
-  else if (strcmp(key, "bisect_iters") == 0) {
-    settings->bisect_iters = atoi(val);
-  }
   else if (strcmp(key, "ruiz_iters") == 0) {
     settings->ruiz_iters = atoi(val);
   }

--- a/docs/contributing/developer_guide.rst
+++ b/docs/contributing/developer_guide.rst
@@ -182,6 +182,79 @@ The file is selected at build time — only one is ever compiled. The CUDA versi
 implements the same logic as CUDA kernels dispatched via the same function
 signatures.
 
+Closed-Form SOC Step Length
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The linesearch for the second-order cone (``soc_step_length`` in ``src/cone.c``)
+computes the maximum step length :math:`\alpha \ge 0` such that
+:math:`x + \alpha \, dx` remains in the second-order cone
+
+.. math::
+
+   \mathcal{Q}^n = \{ (x_0, x_1) \in \mathbb{R} \times \mathbb{R}^{n-1} :
+   x_0 \ge \|x_1\| \}
+
+rather than performing a bisection search.
+
+**Derivation.** The membership condition for :math:`x + \alpha \, dx` is
+
+.. math::
+
+   (x_0 + \alpha \, dx_0)^2 \ge \|x_1 + \alpha \, dx_1\|^2.
+
+Expanding and collecting by powers of :math:`\alpha`:
+
+.. math::
+
+   \underbrace{(dx_0^2 - \|dx_1\|^2)}_{a} \, \alpha^2
+   + \underbrace{2(x_0 \, dx_0 - x_1^\top dx_1)}_{b} \, \alpha
+   + \underbrace{(x_0^2 - \|x_1\|^2)}_{c} \ge 0.
+
+Because :math:`x` is already in the cone, :math:`c = \det(x) = x_0^2 - \|x_1\|^2 \ge 0`,
+so :math:`\alpha = 0` is always feasible. The maximum feasible :math:`\alpha` is
+therefore the smallest positive real root of the quadratic :math:`a \alpha^2 + b \alpha + c = 0`.
+
+**Case analysis.** Before solving the quadratic the code handles four degenerate cases:
+
+1. **Scalar safeguard.** If :math:`dx_0 < 0`, the first component could go negative.
+   An independent upper bound :math:`-x_0 / dx_0` is applied first.
+
+2. **No positive root** (:math:`a > 0` and :math:`b > 0`, or discriminant :math:`d = b^2 - 4ac < 0`).
+   The parabola either opens upward with a positive vertex shift or has no real roots.
+   Either way the quadratic stays non-negative for all :math:`\alpha \ge 0`, so the
+   current bound is returned unchanged.
+
+3. **Linear case** (:math:`|a| < 10^{-14}`). The leading term vanishes; the constraint
+   is linear in :math:`\alpha`. With :math:`c \ge 0` and the sign structure this
+   imposes no additional restriction, so the bound is returned unchanged.
+
+4. **Boundary case** (:math:`c = 0`, i.e. :math:`x` is on the cone boundary). If
+   :math:`a \ge 0` there is no positive root; otherwise :math:`\alpha = 0` is the
+   only feasible point.
+
+**Numerically stable root computation.** When none of the degenerate cases applies,
+Vieta's substitution is used to avoid catastrophic cancellation. Let
+:math:`\sqrt{d} = \sqrt{b^2 - 4ac}`. Define
+
+.. math::
+
+   t = \begin{cases}
+       -b - \sqrt{d} & \text{if } b \ge 0 \\
+       -b + \sqrt{d} & \text{if } b < 0
+   \end{cases}
+
+Then the two roots are computed as
+
+.. math::
+
+   r_1 = \frac{2c}{t}, \qquad r_2 = \frac{t}{2a}.
+
+This form ensures that both :math:`r_1` and :math:`r_2` are computed by dividing
+two numbers of the same sign, avoiding the large relative error that arises when
+subtracting nearly equal quantities. Negative roots are discarded (replaced by
+:math:`+\infty`), and the smaller of :math:`r_1`, :math:`r_2` is taken as the
+step-length restriction for this cone.
+
 Building
 --------
 

--- a/docs/contributing/developer_guide.rst
+++ b/docs/contributing/developer_guide.rst
@@ -233,7 +233,7 @@ therefore the smallest positive real root of the quadratic :math:`a \alpha^2 + b
    only feasible point.
 
 **Numerically stable root computation.** When none of the degenerate cases applies,
-Vieta's substitution is used to avoid catastrophic cancellation. Let
+the citardauq formula is used to avoid catastrophic cancellation. Let
 :math:`\sqrt{d} = \sqrt{b^2 - 4ac}`. Define
 
 .. math::

--- a/docs/qoco/api/settings.rst
+++ b/docs/qoco/api/settings.rst
@@ -12,8 +12,6 @@ The settings are defined in the :code:`include/structs.h` file.
 +================================+=======================+============================================================+=====================+===============+
 | :code:`max_iters`              |  :code:`QOCOInt`      | Maximum number of iterations                               | :math:`(0, \infty)` | 200           |
 +--------------------------------+-----------------------+------------------------------------------------------------+---------------------+---------------+
-| :code:`bisect_iters`           |  :code:`QOCOInt`      | Number of bisection iterations to perform during linesearch| :math:`(0, \infty)` | 5             |
-+--------------------------------+-----------------------+------------------------------------------------------------+---------------------+---------------+
 | :code:`ruiz_iters`             |  :code:`QOCOInt`      | Number of Ruiz equilibration iterations performed          | :math:`(0, \infty)` | 0             |
 +--------------------------------+-----------------------+------------------------------------------------------------+---------------------+---------------+
 | :code:`iter_ref_iters`         |  :code:`QOCOInt`      | Number of iterative refinement iterations to perform       | :math:`(0, \infty)` | 1             |

--- a/include/structs.h
+++ b/include/structs.h
@@ -108,9 +108,6 @@ typedef struct {
   /** Maximum number of IPM iterations. */
   QOCOInt max_iters;
 
-  /** Number of bisection iterations for linesearch. */
-  QOCOInt bisect_iters;
-
   /** Number of Ruiz equilibration iterations. */
   QOCOInt ruiz_iters;
 

--- a/src/cone.c
+++ b/src/cone.c
@@ -377,69 +377,167 @@ void compute_centering(QOCOSolver* solver)
 }
 
 /**
- * @brief Conducts linesearch by bisection to compute a \in (0, 1] such that
- * u + (a / f) * Du \in C
- * Warning: linesearch overwrites ubuff1. Do not pass in ubuff1 into u or Du.
- * Consider a dedicated buffer for linesearch.
+ * @brief Compute maximum step length alpha >= 0 such that
+ * x + alpha * dx remains in the nonnegative orthant.
  */
-QOCOFloat bisection_search(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
-                           QOCOSolver* solver)
+QOCOFloat lp_step_length(const QOCOFloat* x, const QOCOFloat* dx, QOCOInt n,
+                         QOCOFloat alpha_max)
 {
-  QOCOWorkspace* work = solver->work;
-  QOCOFloat* ubuff1 = get_data_vectorf(work->ubuff1);
+  QOCOFloat alpha = alpha_max;
 
-  QOCOFloat al = 0.0;
-  QOCOFloat au = 1.0;
-  QOCOFloat a = 0.0;
-  for (QOCOInt i = 0; i < solver->settings->bisect_iters; ++i) {
-    a = 0.5 * (al + au);
-    qoco_axpy(Du, u, ubuff1, safe_div(a, f), work->data->m);
-    if (cone_residual(ubuff1, work->data->l, work->data->nsoc,
-                      get_data_vectori(work->data->q)) >= 0) {
-      au = a;
-    }
-    else {
-      al = a;
+  for (QOCOInt i = 0; i < n; ++i) {
+    if (dx[i] < 0.0) {
+      alpha = qoco_min(alpha, -x[i] / dx[i]);
     }
   }
-  return al;
+
+  return alpha;
 }
 
 /**
- * @brief Conducts exact linesearch to compute the largest a \in (0, 1] such
- * that u + (a / f) * Du \in C. Currently only works for LP cone.
+ * @brief Compute maximum step length alpha >= 0 such that
+ * x + alpha * dx remains in the second-order cone.
  */
-QOCOFloat exact_linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
-                           QOCOSolver* solver)
+QOCOFloat soc_step_length(const QOCOFloat* x, const QOCOFloat* dx, QOCOInt n,
+                          QOCOFloat alpha_max)
 {
-  QOCOWorkspace* work = solver->work;
+  const QOCOFloat two = 2.0;
+  const QOCOFloat four = 4.0;
 
-  QOCOFloat a = 1.0;
-  QOCOFloat minval = 0;
+  QOCOFloat alpha = alpha_max;
 
-  // Compute a for LP cones.
-  for (QOCOInt i = 0; i < work->data->l; ++i) {
-    if (Du[i] < minval * u[i])
-      minval = Du[i] / u[i];
+  // ----------------------------------
+  // Scalar safeguard: x0 + alpha dx0 >= 0
+  // ----------------------------------
+  if (x[0] >= 0.0 && dx[0] < 0.0) {
+    QOCOFloat a = -x[0] / dx[0];
+    if (a < alpha)
+      alpha = a;
   }
 
-  if (-f < minval)
-    a = f;
-  else
-    a = -f / minval;
+  // ----------------------------------
+  // Compute quadratic coefficients
+  // ----------------------------------
 
-  return a;
+  // a = dx0^2 - ||dx1||^2
+  QOCOFloat dx1_norm2 = 0.0;
+  for (QOCOInt i = 1; i < n; ++i) {
+    dx1_norm2 += dx[i] * dx[i];
+  }
+  QOCOFloat a = dx[0] * dx[0] - dx1_norm2;
+
+  // b = 2*(x0*dx0 - x1^T dx1)
+  QOCOFloat x1dx1 = 0.0;
+  for (QOCOInt i = 1; i < n; ++i) {
+    x1dx1 += x[i] * dx[i];
+  }
+  QOCOFloat b = two * (x[0] * dx[0] - x1dx1);
+
+  // c = x0^2 - ||x1||^2
+  QOCOFloat x1_norm2 = 0.0;
+  for (QOCOInt i = 1; i < n; ++i) {
+    x1_norm2 += x[i] * x[i];
+  }
+  QOCOFloat c = x[0] * x[0] - x1_norm2;
+
+  if (c < 0.0)
+    c = 0.0; // numerical safeguard
+
+  // ----------------------------------
+  // Discriminant
+  // ----------------------------------
+  QOCOFloat d = b * b - four * a * c;
+
+  // ----------------------------------
+  // Case analysis (same as Clarabel)
+  // ----------------------------------
+
+  // No positive root → no restriction
+  if ((a > 0.0 && b > 0.0) || d < 0.0) {
+    return alpha;
+  }
+
+  // Linear case
+  if (qoco_abs(a) < 1e-14) {
+    return alpha;
+  }
+
+  // Boundary case
+  if (c == 0.0) {
+    if (a >= 0.0)
+      return alpha;
+    else
+      return 0.0;
+  }
+
+  // ----------------------------------
+  // Stable quadratic root computation
+  // ----------------------------------
+
+  QOCOFloat sqrt_d = qoco_sqrt(d);
+
+  QOCOFloat t;
+  if (b >= 0.0) {
+    t = -b - sqrt_d;
+  }
+  else {
+    t = -b + sqrt_d;
+  }
+
+  QOCOFloat r1 = (two * c) / t;
+  QOCOFloat r2 = t / (two * a);
+
+  // Keep only positive roots
+  if (r1 < 0.0)
+    r1 = QOCOFloat_MAX;
+  if (r2 < 0.0)
+    r2 = QOCOFloat_MAX;
+
+  QOCOFloat r = qoco_min(r1, r2);
+
+  if (r < alpha)
+    alpha = r;
+
+  return alpha;
+}
+
+QOCOFloat cone_step_length(QOCOFloat* u, QOCOFloat* Du, QOCOProblemData* data)
+{
+  QOCOFloat alpha = 1.0;
+
+  QOCOInt idx = 0;
+
+  // ---------------------------
+  // LP cone
+  // ---------------------------
+  alpha = lp_step_length(&u[idx], &Du[idx], data->l, alpha);
+  idx += data->l;
+
+  // ---------------------------
+  // SOC cones
+  // ---------------------------
+  for (QOCOInt i = 0; i < data->nsoc; ++i) {
+    QOCOInt qi = get_element_vectori(data->q, i);
+
+    QOCOFloat a = soc_step_length(&u[idx], &Du[idx], qi, alpha);
+
+    if (a < alpha)
+      alpha = a;
+
+    idx += qi;
+  }
+
+  return alpha;
 }
 
 QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
                      QOCOSolver* solver)
 {
-  if (solver->work->data->nsoc == 0) {
-    return exact_linesearch(u, Du, f, solver);
-  }
-  else {
-    return bisection_search(u, Du, f, solver);
-  }
+  QOCOWorkspace* work = solver->work;
+
+  QOCOFloat alpha = cone_step_length(u, Du, work->data);
+
+  return f * alpha;
 }
 
 void add_e(QOCOFloat* x, QOCOFloat a, QOCOInt l, QOCOInt nsoc, QOCOVectori* q)

--- a/src/cone.cu
+++ b/src/cone.cu
@@ -618,109 +618,213 @@ void compute_centering(QOCOSolver* solver)
 }
 
 /**
- * @brief Conducts linesearch by bisection to compute a \in (0, 1] such that
- * u + (a / f) * Du \in C
- * Warning: linesearch overwrites ubuff1. Do not pass in ubuff1 into u or Du.
- * Consider a dedicated buffer for linesearch.
+ * @brief Compute maximum step length alpha >= 0 such that
+ * x + alpha * dx remains in the second-order cone.
  */
-QOCOFloat bisection_search(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
-                           QOCOFloat* ubuff, QOCOInt m, QOCOInt l, QOCOInt nsoc,
-                           QOCOInt* q, QOCOInt* soc_idx, QOCOInt bisect_iters)
+__device__ QOCOFloat soc_step_length_dev(const QOCOFloat* x, const QOCOFloat* dx,
+                                          QOCOInt n, QOCOFloat alpha_max)
 {
-  // Single thread only
-  QOCOFloat al = 0.0;
-  QOCOFloat au = 1.0;
-  QOCOFloat a = 0.0;
+  const QOCOFloat two = 2.0;
+  const QOCOFloat four = 4.0;
 
-  for (QOCOInt i = 0; i < bisect_iters; ++i) {
-    a = 0.5 * (al + au);
+  QOCOFloat alpha = alpha_max;
 
-    qoco_axpy(Du, u, ubuff, safe_div(a, f), m);
-
-    if (cone_residual(ubuff, l, nsoc, q, soc_idx) >= 0) {
-      au = a;
-    }
-    else {
-      al = a;
-    }
+  // ----------------------------------
+  // Scalar safeguard: x0 + alpha dx0 >= 0
+  // ----------------------------------
+  if (x[0] >= 0.0 && dx[0] < 0.0) {
+    QOCOFloat a = -x[0] / dx[0];
+    if (a < alpha)
+      alpha = a;
   }
-  return al;
+
+  // ----------------------------------
+  // Compute quadratic coefficients
+  // ----------------------------------
+
+  // a = dx0^2 - ||dx1||^2
+  QOCOFloat dx1_norm2 = 0.0;
+  for (QOCOInt i = 1; i < n; ++i)
+    dx1_norm2 += dx[i] * dx[i];
+  QOCOFloat a = dx[0] * dx[0] - dx1_norm2;
+
+  // b = 2*(x0*dx0 - x1^T dx1)
+  QOCOFloat x1dx1 = 0.0;
+  for (QOCOInt i = 1; i < n; ++i)
+    x1dx1 += x[i] * dx[i];
+  QOCOFloat b = two * (x[0] * dx[0] - x1dx1);
+
+  // c = x0^2 - ||x1||^2
+  QOCOFloat x1_norm2 = 0.0;
+  for (QOCOInt i = 1; i < n; ++i)
+    x1_norm2 += x[i] * x[i];
+  QOCOFloat c = x[0] * x[0] - x1_norm2;
+
+  if (c < 0.0)
+    c = 0.0; // numerical safeguard
+
+  // ----------------------------------
+  // Discriminant
+  // ----------------------------------
+  QOCOFloat d = b * b - four * a * c;
+
+  // ----------------------------------
+  // Case analysis (same as Clarabel)
+  // ----------------------------------
+
+  // No positive root → no restriction
+  if ((a > 0.0 && b > 0.0) || d < 0.0)
+    return alpha;
+
+  // Linear case
+  if (qoco_abs(a) < 1e-14)
+    return alpha;
+
+  // Boundary case
+  if (c == 0.0) {
+    if (a >= 0.0)
+      return alpha;
+    else
+      return 0.0;
+  }
+
+  // ----------------------------------
+  // Stable quadratic root computation
+  // ----------------------------------
+  QOCOFloat sqrt_d = qoco_sqrt(d);
+
+  QOCOFloat t;
+  if (b >= 0.0)
+    t = -b - sqrt_d;
+  else
+    t = -b + sqrt_d;
+
+  QOCOFloat r1 = (two * c) / t;
+  QOCOFloat r2 = t / (two * a);
+
+  // Keep only positive roots
+  if (r1 < 0.0)
+    r1 = QOCOFloat_MAX;
+  if (r2 < 0.0)
+    r2 = QOCOFloat_MAX;
+
+  QOCOFloat r = qoco_min(r1, r2);
+
+  if (r < alpha)
+    alpha = r;
+
+  return alpha;
 }
 
-__global__ void exact_linesearch_stage1(const QOCOFloat* u, const QOCOFloat* Du,
-                                        QOCOInt l, QOCOFloat* block_mins)
+/**
+ * @brief Parallel min reduction kernel: computes min(-x[i]/dx[i]) for dx[i] < 0
+ * over the LP cone. Each block writes its local minimum to block_out.
+ */
+__global__ void lp_step_length_kernel(const QOCOFloat* x, const QOCOFloat* dx,
+                                       QOCOInt n, QOCOFloat* block_out)
 {
   extern __shared__ QOCOFloat sdata[];
 
   QOCOInt tid = threadIdx.x;
   QOCOInt gid = blockIdx.x * blockDim.x + tid;
 
-  /* Initialize with neutral element */
-  QOCOFloat local_min = 0.0;
+  QOCOFloat val = QOCOFloat_MAX;
+  if (gid < n && dx[gid] < 0.0)
+    val = -x[gid] / dx[gid];
 
-  if (gid < l && Du[gid] < 0.0) {
-    local_min = Du[gid] / u[gid]; // negative
-  }
-
-  sdata[tid] = local_min;
+  sdata[tid] = val;
   __syncthreads();
 
-  /* Block-level min reduction */
   for (QOCOInt s = blockDim.x >> 1; s > 0; s >>= 1) {
-    if (tid < s) {
-      if (sdata[tid + s] < sdata[tid]) {
-        sdata[tid] = sdata[tid + s];
-      }
-    }
+    if (tid < s && sdata[tid + s] < sdata[tid])
+      sdata[tid] = sdata[tid + s];
     __syncthreads();
   }
 
-  /* Write block result */
-  if (tid == 0) {
-    block_mins[blockIdx.x] = sdata[0];
+  if (tid == 0)
+    block_out[blockIdx.x] = sdata[0];
+}
+
+/**
+ * @brief Single-thread kernel that sequentially applies the closed-form SOC
+ * step length to every second-order cone and writes the minimum into alpha_inout.
+ */
+__global__ void soc_step_length_kernel(const QOCOFloat* u, const QOCOFloat* Du,
+                                        const QOCOInt* q, QOCOInt nsoc, QOCOInt l,
+                                        QOCOFloat* alpha_inout)
+{
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+
+  QOCOFloat alpha = *alpha_inout;
+  QOCOInt idx = l;
+
+  for (QOCOInt i = 0; i < nsoc; ++i) {
+    QOCOInt qi = q[i];
+    QOCOFloat a = soc_step_length_dev(&u[idx], &Du[idx], qi, alpha);
+    if (a < alpha)
+      alpha = a;
+    idx += qi;
   }
+
+  *alpha_inout = alpha;
 }
 
 QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
                      QOCOSolver* solver)
 {
   QOCOWorkspace* work = solver->work;
-  QOCOProblemData* data = solver->work->data;
+  QOCOProblemData* data = work->data;
 
-  QOCOFloat a_host = 1.0;
+  QOCOFloat alpha = 1.0;
 
-  if (data->nsoc == 0 && data->l > 0) {
+  // ---------------------------
+  // LP cone
+  // ---------------------------
+  if (data->l > 0) {
     int threads = 1024;
     int blocks = (data->l + threads - 1) / threads;
-    QOCOFloat* block_mins;
-    cudaMalloc(&block_mins, blocks * sizeof(QOCOFloat));
 
-    // Produces an array of blocks elements with the min -Du[i]/u[i] for each
-    // block.
-    exact_linesearch_stage1<<<blocks, threads, threads * sizeof(QOCOFloat)>>>(
-        u, Du, data->l, block_mins);
+    QOCOFloat* d_block;
+    CUDA_CHECK(cudaMalloc(&d_block, blocks * sizeof(QOCOFloat)));
+
+    lp_step_length_kernel<<<blocks, threads, threads * sizeof(QOCOFloat)>>>(
+        u, Du, data->l, d_block);
     CUDA_CHECK(cudaGetLastError());
 
-    // Since every element of block_mins is negative, the minimum value is
-    // -inf_norm(block_mins)
-    QOCOFloat a = -inf_norm(block_mins, blocks);
-    if (-f < a) {
-      a_host = f;
+    // Final reduction over blocks on host
+    QOCOFloat* h_block = (QOCOFloat*)malloc(blocks * sizeof(QOCOFloat));
+    CUDA_CHECK(cudaMemcpy(h_block, d_block, blocks * sizeof(QOCOFloat),
+                          cudaMemcpyDeviceToHost));
+
+    for (int i = 0; i < blocks; ++i) {
+      if (h_block[i] < alpha)
+        alpha = h_block[i];
     }
-    else {
-      a_host = -f / a;
-    }
-    cudaFree(block_mins);
+
+    free(h_block);
+    CUDA_CHECK(cudaFree(d_block));
   }
-  else if (data->nsoc > 0) {
-    QOCOFloat* ubuff = get_data_vectorf(work->ubuff1);
-    QOCOInt* q = get_data_vectori(data->q);
-    QOCOInt* soc_idx = get_data_vectori(work->soc_idx);
-    QOCOInt bisect_iters = solver->settings->bisect_iters;
-    a_host = bisection_search(u, Du, f, ubuff, data->m, data->l, data->nsoc, q,
-                              soc_idx, bisect_iters);
+
+  // ---------------------------
+  // SOC cones
+  // ---------------------------
+  if (data->nsoc > 0) {
+    QOCOFloat* d_alpha;
+    CUDA_CHECK(cudaMalloc(&d_alpha, sizeof(QOCOFloat)));
+    CUDA_CHECK(
+        cudaMemcpy(d_alpha, &alpha, sizeof(QOCOFloat), cudaMemcpyHostToDevice));
+
+    soc_step_length_kernel<<<1, 1>>>(u, Du, get_data_vectori(data->q),
+                                     data->nsoc, data->l, d_alpha);
+    CUDA_CHECK(cudaGetLastError());
+
+    CUDA_CHECK(
+        cudaMemcpy(&alpha, d_alpha, sizeof(QOCOFloat), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaFree(d_alpha));
   }
-  return a_host;
+
+  return f * alpha;
 }
 
 void add_e(QOCOFloat* x, QOCOFloat a, QOCOInt l, QOCOInt nsoc, QOCOVectori* q)

--- a/src/cone.cu
+++ b/src/cone.cu
@@ -748,34 +748,18 @@ __global__ void lp_step_length_kernel(const QOCOFloat* x, const QOCOFloat* dx,
 
 /**
  * @brief Parallel kernel: one thread per SOC cone computes the closed-form step
- * length, then a shared-memory min-reduction writes the result into alpha_out.
- * Launch with blockDim.x >= nsoc (rounded up to a power of two).
+ * length and writes it to alpha_out[tid]. Launch with blockDim.x == nsoc.
  */
 __global__ void soc_step_length_kernel(const QOCOFloat* u, const QOCOFloat* Du,
                                        const QOCOInt* q, const QOCOInt* soc_idx,
                                        QOCOInt nsoc, QOCOFloat alpha_lp,
                                        QOCOFloat* alpha_out)
 {
-  extern __shared__ QOCOFloat sdata[];
-
   QOCOInt tid = threadIdx.x;
 
-  QOCOFloat val = alpha_lp;
   if (tid < nsoc)
-    val = soc_step_length_dev(&u[soc_idx[tid]], &Du[soc_idx[tid]], q[tid],
-                              alpha_lp);
-
-  sdata[tid] = val;
-  __syncthreads();
-
-  for (QOCOInt s = blockDim.x >> 1; s > 0; s >>= 1) {
-    if (tid < s && sdata[tid + s] < sdata[tid])
-      sdata[tid] = sdata[tid + s];
-    __syncthreads();
-  }
-
-  if (tid == 0)
-    *alpha_out = sdata[0];
+    alpha_out[tid] = soc_step_length_dev(&u[soc_idx[tid]], &Du[soc_idx[tid]],
+                                         q[tid], alpha_lp);
 }
 
 QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
@@ -818,22 +802,28 @@ QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
   // SOC cones
   // ---------------------------
   if (data->nsoc > 0) {
-    // Round up to the next power of two for the shared-memory reduction.
-    int threads = 1;
-    while (threads < data->nsoc)
-      threads <<= 1;
+    QOCOFloat* d_soc_alphas;
+    CUDA_CHECK(cudaMalloc(&d_soc_alphas, data->nsoc * sizeof(QOCOFloat)));
 
-    QOCOFloat* d_alpha;
-    CUDA_CHECK(cudaMalloc(&d_alpha, sizeof(QOCOFloat)));
-
-    soc_step_length_kernel<<<1, threads, threads * sizeof(QOCOFloat)>>>(
+    soc_step_length_kernel<<<1, data->nsoc>>>(
         u, Du, get_data_vectori(data->q), get_data_vectori(work->soc_idx),
-        data->nsoc, alpha, d_alpha);
+        data->nsoc, alpha, d_soc_alphas);
     CUDA_CHECK(cudaGetLastError());
 
-    CUDA_CHECK(
-        cudaMemcpy(&alpha, d_alpha, sizeof(QOCOFloat), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaFree(d_alpha));
+    // Copy per-SOC step lengths to host and take the minimum.
+    QOCOFloat* h_soc_alphas =
+        (QOCOFloat*)malloc(data->nsoc * sizeof(QOCOFloat));
+    CUDA_CHECK(cudaMemcpy(h_soc_alphas, d_soc_alphas,
+                          data->nsoc * sizeof(QOCOFloat),
+                          cudaMemcpyDeviceToHost));
+
+    for (int i = 0; i < data->nsoc; ++i) {
+      if (h_soc_alphas[i] < alpha)
+        alpha = h_soc_alphas[i];
+    }
+
+    free(h_soc_alphas);
+    CUDA_CHECK(cudaFree(d_soc_alphas));
   }
 
   // Safeguard against step-sizes which are too small.

--- a/src/cone.cu
+++ b/src/cone.cu
@@ -621,8 +621,9 @@ void compute_centering(QOCOSolver* solver)
  * @brief Compute maximum step length alpha >= 0 such that
  * x + alpha * dx remains in the second-order cone.
  */
-__device__ QOCOFloat soc_step_length_dev(const QOCOFloat* x, const QOCOFloat* dx,
-                                          QOCOInt n, QOCOFloat alpha_max)
+__device__ QOCOFloat soc_step_length_dev(const QOCOFloat* x,
+                                         const QOCOFloat* dx, QOCOInt n,
+                                         QOCOFloat alpha_max)
 {
   const QOCOFloat two = 2.0;
   const QOCOFloat four = 4.0;
@@ -721,7 +722,7 @@ __device__ QOCOFloat soc_step_length_dev(const QOCOFloat* x, const QOCOFloat* dx
  * over the LP cone. Each block writes its local minimum to block_out.
  */
 __global__ void lp_step_length_kernel(const QOCOFloat* x, const QOCOFloat* dx,
-                                       QOCOInt n, QOCOFloat* block_out)
+                                      QOCOInt n, QOCOFloat* block_out)
 {
   extern __shared__ QOCOFloat sdata[];
 
@@ -746,28 +747,35 @@ __global__ void lp_step_length_kernel(const QOCOFloat* x, const QOCOFloat* dx,
 }
 
 /**
- * @brief Single-thread kernel that sequentially applies the closed-form SOC
- * step length to every second-order cone and writes the minimum into alpha_inout.
+ * @brief Parallel kernel: one thread per SOC cone computes the closed-form step
+ * length, then a shared-memory min-reduction writes the result into alpha_out.
+ * Launch with blockDim.x >= nsoc (rounded up to a power of two).
  */
 __global__ void soc_step_length_kernel(const QOCOFloat* u, const QOCOFloat* Du,
-                                        const QOCOInt* q, QOCOInt nsoc, QOCOInt l,
-                                        QOCOFloat* alpha_inout)
+                                       const QOCOInt* q, const QOCOInt* soc_idx,
+                                       QOCOInt nsoc, QOCOFloat alpha_lp,
+                                       QOCOFloat* alpha_out)
 {
-  if (threadIdx.x != 0 || blockIdx.x != 0)
-    return;
+  extern __shared__ QOCOFloat sdata[];
 
-  QOCOFloat alpha = *alpha_inout;
-  QOCOInt idx = l;
+  QOCOInt tid = threadIdx.x;
 
-  for (QOCOInt i = 0; i < nsoc; ++i) {
-    QOCOInt qi = q[i];
-    QOCOFloat a = soc_step_length_dev(&u[idx], &Du[idx], qi, alpha);
-    if (a < alpha)
-      alpha = a;
-    idx += qi;
+  QOCOFloat val = alpha_lp;
+  if (tid < nsoc)
+    val = soc_step_length_dev(&u[soc_idx[tid]], &Du[soc_idx[tid]], q[tid],
+                              alpha_lp);
+
+  sdata[tid] = val;
+  __syncthreads();
+
+  for (QOCOInt s = blockDim.x >> 1; s > 0; s >>= 1) {
+    if (tid < s && sdata[tid + s] < sdata[tid])
+      sdata[tid] = sdata[tid + s];
+    __syncthreads();
   }
 
-  *alpha_inout = alpha;
+  if (tid == 0)
+    *alpha_out = sdata[0];
 }
 
 QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
@@ -810,18 +818,27 @@ QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
   // SOC cones
   // ---------------------------
   if (data->nsoc > 0) {
+    // Round up to the next power of two for the shared-memory reduction.
+    int threads = 1;
+    while (threads < data->nsoc)
+      threads <<= 1;
+
     QOCOFloat* d_alpha;
     CUDA_CHECK(cudaMalloc(&d_alpha, sizeof(QOCOFloat)));
-    CUDA_CHECK(
-        cudaMemcpy(d_alpha, &alpha, sizeof(QOCOFloat), cudaMemcpyHostToDevice));
 
-    soc_step_length_kernel<<<1, 1>>>(u, Du, get_data_vectori(data->q),
-                                     data->nsoc, data->l, d_alpha);
+    soc_step_length_kernel<<<1, threads, threads * sizeof(QOCOFloat)>>>(
+        u, Du, get_data_vectori(data->q), get_data_vectori(work->soc_idx),
+        data->nsoc, alpha, d_alpha);
     CUDA_CHECK(cudaGetLastError());
 
     CUDA_CHECK(
         cudaMemcpy(&alpha, d_alpha, sizeof(QOCOFloat), cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaFree(d_alpha));
+  }
+
+  // Safeguard against step-sizes which are too small.
+  if (alpha < 1e-12) {
+    return 0;
   }
 
   return f * alpha;

--- a/src/cone.cu
+++ b/src/cone.cu
@@ -748,18 +748,35 @@ __global__ void lp_step_length_kernel(const QOCOFloat* x, const QOCOFloat* dx,
 
 /**
  * @brief Parallel kernel: one thread per SOC cone computes the closed-form step
- * length and writes it to alpha_out[tid]. Launch with blockDim.x == nsoc.
+ * length, then a shared-memory min-reduction writes each block's minimum to
+ * block_out. Launch with blockDim.x == 1024.
  */
 __global__ void soc_step_length_kernel(const QOCOFloat* u, const QOCOFloat* Du,
                                        const QOCOInt* q, const QOCOInt* soc_idx,
                                        QOCOInt nsoc, QOCOFloat alpha_lp,
-                                       QOCOFloat* alpha_out)
+                                       QOCOFloat* block_out)
 {
-  QOCOInt tid = threadIdx.x;
+  extern __shared__ QOCOFloat sdata[];
 
-  if (tid < nsoc)
-    alpha_out[tid] = soc_step_length_dev(&u[soc_idx[tid]], &Du[soc_idx[tid]],
-                                         q[tid], alpha_lp);
+  QOCOInt tid = threadIdx.x;
+  QOCOInt gid = blockIdx.x * blockDim.x + tid;
+
+  QOCOFloat val = QOCOFloat_MAX;
+  if (gid < nsoc)
+    val = soc_step_length_dev(&u[soc_idx[gid]], &Du[soc_idx[gid]], q[gid],
+                              alpha_lp);
+
+  sdata[tid] = val;
+  __syncthreads();
+
+  for (QOCOInt s = blockDim.x >> 1; s > 0; s >>= 1) {
+    if (tid < s && sdata[tid + s] < sdata[tid])
+      sdata[tid] = sdata[tid + s];
+    __syncthreads();
+  }
+
+  if (tid == 0)
+    block_out[blockIdx.x] = sdata[0];
 }
 
 QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
@@ -802,28 +819,29 @@ QOCOFloat linesearch(QOCOFloat* u, QOCOFloat* Du, QOCOFloat f,
   // SOC cones
   // ---------------------------
   if (data->nsoc > 0) {
-    QOCOFloat* d_soc_alphas;
-    CUDA_CHECK(cudaMalloc(&d_soc_alphas, data->nsoc * sizeof(QOCOFloat)));
+    int threads = 1024;
+    int blocks = (data->nsoc + threads - 1) / threads;
 
-    soc_step_length_kernel<<<1, data->nsoc>>>(
+    QOCOFloat* d_block;
+    CUDA_CHECK(cudaMalloc(&d_block, blocks * sizeof(QOCOFloat)));
+
+    soc_step_length_kernel<<<blocks, threads, threads * sizeof(QOCOFloat)>>>(
         u, Du, get_data_vectori(data->q), get_data_vectori(work->soc_idx),
-        data->nsoc, alpha, d_soc_alphas);
+        data->nsoc, alpha, d_block);
     CUDA_CHECK(cudaGetLastError());
 
-    // Copy per-SOC step lengths to host and take the minimum.
-    QOCOFloat* h_soc_alphas =
-        (QOCOFloat*)malloc(data->nsoc * sizeof(QOCOFloat));
-    CUDA_CHECK(cudaMemcpy(h_soc_alphas, d_soc_alphas,
-                          data->nsoc * sizeof(QOCOFloat),
+    // Final reduction over blocks on host.
+    QOCOFloat* h_block = (QOCOFloat*)malloc(blocks * sizeof(QOCOFloat));
+    CUDA_CHECK(cudaMemcpy(h_block, d_block, blocks * sizeof(QOCOFloat),
                           cudaMemcpyDeviceToHost));
 
-    for (int i = 0; i < data->nsoc; ++i) {
-      if (h_soc_alphas[i] < alpha)
-        alpha = h_soc_alphas[i];
+    for (int i = 0; i < blocks; ++i) {
+      if (h_block[i] < alpha)
+        alpha = h_block[i];
     }
 
-    free(h_soc_alphas);
-    CUDA_CHECK(cudaFree(d_soc_alphas));
+    free(h_block);
+    CUDA_CHECK(cudaFree(d_block));
   }
 
   // Safeguard against step-sizes which are too small.

--- a/src/input_validation.c
+++ b/src/input_validation.c
@@ -24,12 +24,6 @@ QOCOInt qoco_validate_settings(const QOCOSettings* settings)
     return QOCO_SETTINGS_VALIDATION_ERROR;
   }
 
-  // bisection_iters must be positive.
-  if (settings->bisect_iters <= 0) {
-    printf("bisect_iters must be positive.\n");
-    return QOCO_SETTINGS_VALIDATION_ERROR;
-  }
-
   // abstol must be positive.
   if (settings->abstol <= 0) {
     printf("abstol must be positive.\n");

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -226,7 +226,6 @@ void qoco_set_csc(QOCOCscMatrix* A, QOCOInt m, QOCOInt n, QOCOInt Annz,
 void set_default_settings(QOCOSettings* settings)
 {
   settings->max_iters = 200;
-  settings->bisect_iters = 5;
   settings->ruiz_iters = 0;
   settings->iter_ref_iters = 1;
   settings->kkt_static_reg = 1e-8;
@@ -246,7 +245,6 @@ QOCOInt qoco_update_settings(QOCOSolver* solver,
   }
 
   solver->settings->max_iters = new_settings->max_iters;
-  solver->settings->bisect_iters = new_settings->bisect_iters;
   solver->settings->ruiz_iters = new_settings->ruiz_iters;
   solver->settings->iter_ref_iters = new_settings->iter_ref_iters;
   solver->settings->kkt_static_reg = new_settings->kkt_static_reg;

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -178,9 +178,8 @@ void print_header(QOCOSolver* solver)
   printf("|     algebra: %-27s              |\n", solver->linsys->linsys_name());
   printf("|     max_iters: %-3d abstol: %3.2e reltol: %3.2e  |\n", settings->max_iters, settings->abstol, settings->reltol);
   printf("|     abstol_inacc: %3.2e reltol_inacc: %3.2e     |\n", settings->abstol_inacc, settings->reltol_inacc);
-  printf("|     bisect_iters: %-2d iter_ref_iters: %-2d               |\n", settings->bisect_iters, settings->iter_ref_iters);
-  printf("|     ruiz_iters: %-2d kkt_static_reg: %3.2e           |\n", settings->ruiz_iters, settings->kkt_static_reg);
-  printf("|     kkt_dynamic_reg: %3.2e                         |\n", settings->kkt_dynamic_reg);
+  printf("|     ruiz_iters: %-2d iter_ref_iters: %-2d               |\n", settings->ruiz_iters, settings->iter_ref_iters);
+  printf("|     kkt_static_reg: %3.2e kkt_dynamic_reg: %3.2e           |\n", settings->kkt_static_reg, settings->kkt_dynamic_reg);
   printf("+-------------------------------------------------------+\n");
   printf("\n");
   printf("+--------+-----------+------------+------------+------------+-----------+-----------+\n");
@@ -377,7 +376,6 @@ QOCOSettings* copy_settings(QOCOSettings* settings)
   QOCOSettings* new_settings = malloc(sizeof(QOCOSettings));
   new_settings->abstol = settings->abstol;
   new_settings->abstol_inacc = settings->abstol_inacc;
-  new_settings->bisect_iters = settings->bisect_iters;
   new_settings->iter_ref_iters = settings->iter_ref_iters;
   new_settings->max_iters = settings->max_iters;
   new_settings->kkt_static_reg = settings->kkt_static_reg;

--- a/tests/unit_tests/input_validation_test.cpp
+++ b/tests/unit_tests/input_validation_test.cpp
@@ -43,17 +43,9 @@ TEST(input_validation, settings_validation)
   QOCOSolver* solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));
 
   set_default_settings(settings);
-  settings->bisect_iters = 0;
+  settings->max_iters = 0;
   QOCOInt exit =
       qoco_setup(solver, n, m, p, P, c, A, b, G, h, l, nsoc, q, settings);
-  EXPECT_EQ(exit, QOCO_SETTINGS_VALIDATION_ERROR);
-  settings->bisect_iters = -1;
-  exit = qoco_setup(solver, n, m, p, P, c, A, b, G, h, l, nsoc, q, settings);
-  EXPECT_EQ(exit, QOCO_SETTINGS_VALIDATION_ERROR);
-
-  set_default_settings(settings);
-  settings->max_iters = 0;
-  exit = qoco_setup(solver, n, m, p, P, c, A, b, G, h, l, nsoc, q, settings);
   EXPECT_EQ(exit, QOCO_SETTINGS_VALIDATION_ERROR);
   settings->max_iters = -1;
   exit = qoco_setup(solver, n, m, p, P, c, A, b, G, h, l, nsoc, q, settings);


### PR DESCRIPTION
See Issue: https://github.com/qoco-org/qoco/issues/57 by @JonasBreuling 

TODO:

- [x] Re-run QOCO benchmarks as a regression check
- [x] Implement same change in `cone.cu`
- [x] Re-run QOCO-GPU benchmarks as a regression check
- [x] Remove bisection iteration setting from code and documentation
