### PR TITLE
Optional custom x0 for IPM initialization

### DIFF
--- a/docs/qoco/api/C.rst
+++ b/docs/qoco/api/C.rst
@@ -23,6 +23,7 @@ Helper functions
 .. doxygenfunction:: set_default_settings
 .. doxygenfunction:: qoco_update_settings
 .. doxygenfunction:: qoco_update_vector_data
+.. doxygenfunction:: qoco_set_x0
 .. doxygenfunction:: qoco_update_matrix_data
 
 QOCO data types

--- a/include/qoco_api.h
+++ b/include/qoco_api.h
@@ -104,6 +104,17 @@ void qoco_update_vector_data(QOCOSolver* solver, QOCOFloat* cnew,
                              QOCOFloat* bnew, QOCOFloat* hnew);
 
 /**
+ * @brief Sets an optional primal starting point after qoco_setup. The x0 vector
+ * is copied and should be supplied in the original, unequilibrated problem
+ * scaling. Pass NULL to clear a previously set custom starting point.
+ *
+ * @param solver Pointer to solver.
+ * @param x0 Primal starting point of length n, or NULL to use default
+ * initialization.
+ */
+void qoco_set_x0(QOCOSolver* solver, const QOCOFloat* x0);
+
+/**
  * @brief Updates data matrices. NULL can be passed in for any matrix data
  * pointers if that matrix will not be updated. It is assumed that the new
  * matrix will have the same sparsity structure as the existing matrix.

--- a/include/structs.h
+++ b/include/structs.h
@@ -197,6 +197,12 @@ typedef struct {
   /** Iterate of primal variables. */
   QOCOVectorf* x;
 
+  /** Primal starting point in original problem scaling. */
+  QOCOVectorf* x0;
+
+  /** Whether to use x0 during initialization. */
+  unsigned char use_x0;
+
   /** Iterate of slack variables associated with conic constraint. */
   QOCOVectorf* s;
 

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -218,6 +218,21 @@ void initialize_ipm(QOCOSolver* solver)
   // Bring s and z to cone C.
   bring2cone(get_data_vectorf(work->s), get_data_vectori(work->soc_idx), data);
   bring2cone(get_data_vectorf(work->z), get_data_vectori(work->soc_idx), data);
+
+  if (work->use_x0) {
+    QOCOFloat* x0 = get_data_vectorf(work->x0);
+    QOCOFloat* x = get_data_vectorf(work->x);
+    QOCOFloat* Dinvruiz = get_data_vectorf(work->scaling->Dinvruiz);
+    ew_product(x0, Dinvruiz, x, data->n);
+
+    if (data->m > 0) {
+      QOCOFloat* s = get_data_vectorf(work->s);
+      QOCOFloat* h = get_data_vectorf(data->h);
+      SpMv(data->G, x, s);
+      qoco_axpy(s, h, s, -1.0, data->m);
+      bring2cone(s, get_data_vectori(work->soc_idx), data);
+    }
+  }
 }
 
 void compute_kkt_residual(QOCOProblemData* data, QOCOVectorf* x_vec,

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -157,6 +157,8 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
 
   // Allocate primal and dual variables.
   work->x = new_qoco_vectorf(NULL, n);
+  work->x0 = new_qoco_vectorf(NULL, n);
+  work->use_x0 = 0;
   work->s = new_qoco_vectorf(NULL, m);
   work->y = new_qoco_vectorf(NULL, p);
   work->z = new_qoco_vectorf(NULL, m);
@@ -319,6 +321,25 @@ void qoco_update_vector_data(QOCOSolver* solver, QOCOFloat* cnew,
   sync_vector_to_device(data->c);
   sync_vector_to_device(data->b);
   sync_vector_to_device(data->h);
+}
+
+void qoco_set_x0(QOCOSolver* solver, const QOCOFloat* x0)
+{
+  QOCOWorkspace* work = solver->work;
+
+  if (!x0) {
+    work->use_x0 = 0;
+    solver->sol->status = QOCO_UNSOLVED;
+    return;
+  }
+
+  set_cpu_mode(1);
+  copy_arrayf(x0, get_data_vectorf(work->x0), work->data->n);
+  set_cpu_mode(0);
+  sync_vector_to_device(work->x0);
+
+  work->use_x0 = 1;
+  solver->sol->status = QOCO_UNSOLVED;
 }
 
 void qoco_update_matrix_data(QOCOSolver* solver, QOCOFloat* Pxnew,
@@ -528,6 +549,7 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
   free_qoco_vectorf(solver->work->xyz);
   free_qoco_vectorf(solver->work->xyzbuff1);
   free_qoco_vectorf(solver->work->x);
+  free_qoco_vectorf(solver->work->x0);
   free_qoco_vectorf(solver->work->s);
   free_qoco_vectorf(solver->work->y);
   free_qoco_vectorf(solver->work->z);

--- a/tests/unit_tests/x0_test.cpp
+++ b/tests/unit_tests/x0_test.cpp
@@ -1,0 +1,145 @@
+#include "qoco.h"
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+
+namespace {
+
+void set_single_iteration_accept_settings(QOCOSettings* settings)
+{
+  set_default_settings(settings);
+  settings->max_iters = 1;
+  settings->ruiz_iters = 0;
+  settings->abstol = 1e20;
+  settings->reltol = 1e20;
+  settings->verbose = 0;
+}
+
+QOCOSolver* setup_unconstrained_qp(QOCOFloat c0, QOCOFloat c1,
+                                   QOCOInt ruiz_iters = 0)
+{
+  QOCOInt n = 2;
+  QOCOInt m = 0;
+  QOCOInt p = 0;
+  QOCOInt l = 0;
+  QOCOInt nsoc = 0;
+
+  QOCOFloat Px[] = {1, 1};
+  QOCOInt Pp[] = {0, 1, 2};
+  QOCOInt Pi[] = {0, 1};
+  QOCOFloat c[] = {c0, c1};
+  QOCOCscMatrix P;
+  qoco_set_csc(&P, n, n, 2, Px, Pp, Pi);
+
+  QOCOSettings settings;
+  set_single_iteration_accept_settings(&settings);
+  settings.ruiz_iters = ruiz_iters;
+
+  QOCOSolver* solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));
+  QOCOInt exit = qoco_setup(solver, n, m, p, &P, c, nullptr, nullptr, nullptr,
+                            nullptr, l, nsoc, nullptr, &settings);
+  EXPECT_EQ(exit, QOCO_NO_ERROR);
+  if (exit != QOCO_NO_ERROR) {
+    free(solver);
+    return nullptr;
+  }
+  return solver;
+}
+
+void expect_near_array(const QOCOFloat* actual, const QOCOFloat* expected,
+                       QOCOInt n, QOCOFloat tol)
+{
+  for (QOCOInt i = 0; i < n; ++i) {
+    EXPECT_NEAR(actual[i], expected[i], tol);
+  }
+}
+
+} // namespace
+
+TEST(x0, custom_primal_start_uses_original_scaling)
+{
+  QOCOSolver* solver = setup_unconstrained_qp(1, 1, 1);
+  ASSERT_NE(solver, nullptr);
+
+  QOCOFloat x0[] = {2.5, -3.0};
+  qoco_set_x0(solver, x0);
+  QOCOInt exit = qoco_solve(solver);
+
+  ASSERT_EQ(exit, QOCO_SOLVED);
+  expect_near_array(solver->sol->x, x0, 2, 1e-6);
+
+  qoco_cleanup(solver);
+}
+
+TEST(x0, custom_primal_start_is_copied)
+{
+  QOCOSolver* solver = setup_unconstrained_qp(1, 2);
+  ASSERT_NE(solver, nullptr);
+
+  QOCOFloat x0[] = {2.0, -3.0};
+  QOCOFloat x0_expected[] = {2.0, -3.0};
+  qoco_set_x0(solver, x0);
+  x0[0] = 99.0;
+  x0[1] = 99.0;
+
+  QOCOInt exit = qoco_solve(solver);
+
+  ASSERT_EQ(exit, QOCO_SOLVED);
+  expect_near_array(solver->sol->x, x0_expected, 2, 1e-6);
+
+  qoco_cleanup(solver);
+}
+
+TEST(x0, custom_primal_start_can_be_cleared)
+{
+  QOCOSolver* solver = setup_unconstrained_qp(1, 2);
+  ASSERT_NE(solver, nullptr);
+
+  QOCOFloat x0[] = {2.0, -3.0};
+  qoco_set_x0(solver, x0);
+  qoco_set_x0(solver, nullptr);
+
+  QOCOInt exit = qoco_solve(solver);
+
+  QOCOFloat default_start[] = {-1.0, -2.0};
+  ASSERT_EQ(exit, QOCO_SOLVED);
+  expect_near_array(solver->sol->x, default_start, 2, 1e-6);
+
+  qoco_cleanup(solver);
+}
+
+TEST(x0, custom_primal_start_sets_consistent_linear_cone_slack)
+{
+  QOCOInt n = 2;
+  QOCOInt m = 3;
+  QOCOInt p = 0;
+  QOCOInt l = 3;
+  QOCOInt nsoc = 0;
+
+  QOCOFloat Gx[] = {-1, 1, -1, 1};
+  QOCOInt Gp[] = {0, 2, 4};
+  QOCOInt Gi[] = {0, 2, 1, 2};
+  QOCOFloat c[] = {-1, -2};
+  QOCOFloat h[] = {0, 0, 1};
+  QOCOCscMatrix G;
+  qoco_set_csc(&G, m, n, 4, Gx, Gp, Gi);
+
+  QOCOSettings settings;
+  set_single_iteration_accept_settings(&settings);
+
+  QOCOSolver* solver = (QOCOSolver*)malloc(sizeof(QOCOSolver));
+  QOCOInt exit = qoco_setup(solver, n, m, p, nullptr, c, nullptr, nullptr, &G,
+                            h, l, nsoc, nullptr, &settings);
+  ASSERT_EQ(exit, QOCO_NO_ERROR);
+
+  QOCOFloat x0[] = {0.25, 0.5};
+  QOCOFloat s0_expected[] = {0.25, 0.5, 0.25};
+  qoco_set_x0(solver, x0);
+  exit = qoco_solve(solver);
+
+  ASSERT_EQ(exit, QOCO_SOLVED);
+  expect_near_array(solver->sol->x, x0, n, 1e-6);
+  expect_near_array(solver->sol->s, s0_expected, m, 1e-6);
+
+  qoco_cleanup(solver);
+}

--- a/tests/unit_tests/x0_test.cpp
+++ b/tests/unit_tests/x0_test.cpp
@@ -1,4 +1,5 @@
 #include "qoco.h"
+#include "test_utils.h"
 #include "gtest/gtest.h"
 
 #include <cstdlib>
@@ -46,14 +47,6 @@ QOCOSolver* setup_unconstrained_qp(QOCOFloat c0, QOCOFloat c1,
   return solver;
 }
 
-void expect_near_array(const QOCOFloat* actual, const QOCOFloat* expected,
-                       QOCOInt n, QOCOFloat tol)
-{
-  for (QOCOInt i = 0; i < n; ++i) {
-    EXPECT_NEAR(actual[i], expected[i], tol);
-  }
-}
-
 } // namespace
 
 TEST(x0, custom_primal_start_uses_original_scaling)
@@ -66,7 +59,7 @@ TEST(x0, custom_primal_start_uses_original_scaling)
   QOCOInt exit = qoco_solve(solver);
 
   ASSERT_EQ(exit, QOCO_SOLVED);
-  expect_near_array(solver->sol->x, x0, 2, 1e-6);
+  expect_eq_vectorf(solver->sol->x, x0, 2, 1e-6);
 
   qoco_cleanup(solver);
 }
@@ -85,7 +78,7 @@ TEST(x0, custom_primal_start_is_copied)
   QOCOInt exit = qoco_solve(solver);
 
   ASSERT_EQ(exit, QOCO_SOLVED);
-  expect_near_array(solver->sol->x, x0_expected, 2, 1e-6);
+  expect_eq_vectorf(solver->sol->x, x0_expected, 2, 1e-6);
 
   qoco_cleanup(solver);
 }
@@ -103,7 +96,7 @@ TEST(x0, custom_primal_start_can_be_cleared)
 
   QOCOFloat default_start[] = {-1.0, -2.0};
   ASSERT_EQ(exit, QOCO_SOLVED);
-  expect_near_array(solver->sol->x, default_start, 2, 1e-6);
+  expect_eq_vectorf(solver->sol->x, default_start, 2, 1e-6);
 
   qoco_cleanup(solver);
 }
@@ -138,8 +131,8 @@ TEST(x0, custom_primal_start_sets_consistent_linear_cone_slack)
   exit = qoco_solve(solver);
 
   ASSERT_EQ(exit, QOCO_SOLVED);
-  expect_near_array(solver->sol->x, x0, n, 1e-6);
-  expect_near_array(solver->sol->s, s0_expected, m, 1e-6);
+  expect_eq_vectorf(solver->sol->x, x0, n, 1e-6);
+  expect_eq_vectorf(solver->sol->s, s0_expected, m, 1e-6);
 
   qoco_cleanup(solver);
 }


### PR DESCRIPTION
Adds `qoco_set_x0()` so callers can pass an optional primal starting point after `qoco_setup()` and before `qoco_solve()`

When `x0` is set, QOCO copies it into the workspace and treats it as being in the original problem scaling. During init proc we use it for the starting point for `x` (obviously), recompute `s0 = h - Gx0`, and push `s0` into the cone interior via `bring2cone` if needed. The existing initializer still picks `y0` and an interior `z0`

Also adds the C API docs and tests for copying `x0`, clearing it with `NULL`, scaling behavior, and slack init