### PR TITLE
Add best-iterate restoration on numerical-error / max-iter exits

### DIFF
--- a/docs/contributing/developer_guide.rst
+++ b/docs/contributing/developer_guide.rst
@@ -419,7 +419,9 @@ tests three residuals in the **original (unscaled) problem space**:
 
 - **Primal residual** :math:`r_p = \max(\|Ax - b\|_\infty,\ \|Gx + s - h\|_\infty)`
 - **Dual residual** :math:`r_d = \|Px + c + A^\top y + G^\top z\|_\infty`
-- **Duality gap** :math:`\mu = s^\top z`
+- **Duality gap** :math:`g = s^\top z` (note: distinct from
+  :math:`\mu = s^\top z / m`, the per-component complementarity used by
+  the predictor-corrector)
 
 The solver declares ``QOCO_SOLVED`` when all three satisfy an
 absolute-plus-relative threshold simultaneously:
@@ -430,7 +432,7 @@ absolute-plus-relative threshold simultaneously:
           \max(\|Ax\|_\infty,\, \|b\|_\infty,\, \|Gx\|_\infty,\, \|h\|_\infty,\, \|s\|_\infty) \\
    r_d &< \varepsilon_{\text{abs}} + \varepsilon_{\text{rel}} \cdot
           \max(\|Px\|_\infty,\, \|A^\top y\|_\infty,\, \|G^\top z\|_\infty,\, \|c\|_\infty) \\
-   \mu  &< \varepsilon_{\text{abs}} + \varepsilon_{\text{rel}} \cdot
+   g   &< \varepsilon_{\text{abs}} + \varepsilon_{\text{rel}} \cdot
           \max(1,\, |p_{\text{obj}}|,\, |d_{\text{obj}}|)
 
 where :math:`\varepsilon_{\text{abs}}` = ``abstol`` and
@@ -438,6 +440,61 @@ where :math:`\varepsilon_{\text{abs}}` = ``abstol`` and
 Because QOCO equilibrates the problem internally, the Ruiz scaling factors are
 unwound before computing each norm so that the residuals reflect the original
 problem data.
+
+Best-Iterate Restoration
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The interior-point sequence is not monotone in :math:`(r_p, r_d, g)` — a late
+iteration can degrade after the iterates have already passed close to the
+solution, and a NaN-producing factorization can blow up an otherwise good
+iterate. To avoid returning a worse point than the solver actually found, QOCO
+maintains a checkpoint of the best iterate seen so far and falls back to it on
+non-success exits.
+
+The "best" iterate is defined by a composite progress metric, computed in
+``check_stopping`` (``src/qoco_utils.c``) on the same unscaled residuals used by
+the regular stopping check:
+
+.. math::
+
+   M = \max\!\left(
+     \frac{r_p}{\varepsilon^{\text{inacc}}_{\text{abs}} + \varepsilon^{\text{inacc}}_{\text{rel}} \cdot s_p},\
+     \frac{r_d}{\varepsilon^{\text{inacc}}_{\text{abs}} + \varepsilon^{\text{inacc}}_{\text{rel}} \cdot s_d},\
+     \frac{g  }{\varepsilon^{\text{inacc}}_{\text{abs}} + \varepsilon^{\text{inacc}}_{\text{rel}} \cdot s_g}
+   \right)
+
+where :math:`s_p, s_d, s_g` are the same scale factors used for the absolute /
+relative stopping check and :math:`\varepsilon^{\text{inacc}}_{\text{abs}}` =
+``abstol_inacc``, :math:`\varepsilon^{\text{inacc}}_{\text{rel}}` =
+``reltol_inacc``. :math:`M` is in *inaccurate-tolerance units*: :math:`M \le 1`
+exactly when the current iterate already satisfies the inaccurate stopping
+criterion on all three residuals simultaneously, and smaller is always better.
+Combining all three residuals into one scalar avoids the ambiguity of
+multi-objective comparisons (e.g. lower :math:`r_p` but higher :math:`g`).
+
+Each iteration with a finite :math:`M` strictly smaller than the previous best
+overwrites the saved checkpoint. The checkpoint stores ``x``, ``s``, ``y``,
+``z`` in scaled space along with :math:`r_p`, :math:`r_d`, :math:`g`,
+:math:`p_{\text{obj}}`, the metric value, and the iteration index, in the
+``best_*`` fields of ``QOCOWorkspace``.
+
+``restore_best_iterate`` (``src/qoco_utils.c``) is invoked from ``qoco_solve``
+on two exit paths:
+
+- **Numerical error** — when ``check_stopping`` returns ``QOCO_NUMERICAL_ERROR``
+  (dynamic regularization has saturated and the inaccurate check on the
+  *current* iterate failed).
+- **Max-iter** — when the IPM loop exits without converging.
+
+If the restored iterate satisfies :math:`M \le 1`, the status is upgraded
+from ``QOCO_NUMERICAL_ERROR`` / ``QOCO_MAX_ITER`` to ``QOCO_SOLVED_INACCURATE``.
+Restoration runs *before* ``unscale_variables`` and ``copy_solution``, so the
+returned ``QOCOSolution`` always corresponds to the best iterate the solver
+visited, not the diverged final state.
+
+Restoration is a no-op when no best iterate has been recorded (``best_valid``
+is zero), which protects the case where the very first ``check_stopping`` call
+produces a non-finite metric.
 
 Building
 --------

--- a/include/qoco_utils.h
+++ b/include/qoco_utils.h
@@ -87,6 +87,16 @@ void print_footer(QOCOSolution* solution, enum qoco_solve_status status);
 unsigned char check_stopping(QOCOSolver* solver);
 
 /**
+ * @brief Restore the best iterate (saved during solve) into work->{x,s,y,z}
+ * and copy its residuals/objective into solver->sol. Updates the solver
+ * status if the saved iterate satisfies the inaccurate tolerance. Has no
+ * effect if no best iterate has been recorded.
+ *
+ * @param solver Pointer to solver.
+ */
+void restore_best_iterate(QOCOSolver* solver);
+
+/**
  * @brief Copies data to QOCOSolution struct when solver terminates.
  *
  * @param solver Pointer to solver.

--- a/include/qoco_utils.h
+++ b/include/qoco_utils.h
@@ -93,8 +93,9 @@ unsigned char check_stopping(QOCOSolver* solver);
  * effect if no best iterate has been recorded.
  *
  * @param solver Pointer to solver.
+ * @return 1 if a best iterate was restored, 0 otherwise.
  */
-void restore_best_iterate(QOCOSolver* solver);
+unsigned char restore_best_iterate(QOCOSolver* solver);
 
 /**
  * @brief Copies data to QOCOSolution struct when solver terminates.

--- a/include/structs.h
+++ b/include/structs.h
@@ -287,6 +287,22 @@ typedef struct {
   /** Total iterative refinement iterations used in the current IPM step. */
   QOCOInt ir_iters;
 
+  /** Best iterate found so far (scaled space), saved by composite residual
+   * metric. Restored on numerical-error / max-iter exits. */
+  QOCOVectorf* best_x;
+  QOCOVectorf* best_s;
+  QOCOVectorf* best_y;
+  QOCOVectorf* best_z;
+
+  /** Residuals associated with the saved best iterate. */
+  QOCOFloat best_pres;
+  QOCOFloat best_dres;
+  QOCOFloat best_gap;
+  QOCOFloat best_obj;
+  QOCOFloat best_metric;
+  QOCOInt best_iter;
+  unsigned char best_valid;
+
 } QOCOWorkspace;
 
 typedef struct {

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -471,7 +471,7 @@ QOCOInt qoco_solve(QOCOSolver* solver)
     if (check_stopping(solver)) {
       stop_timer(&(work->solve_timer));
       // On numerical error, restore the best iterate seen so far. The helper
-      // can downgrade the status to QOCO_SOLVED_INACCURATE if the saved
+      // can upgrade the status to QOCO_SOLVED_INACCURATE if the saved
       // iterate satisfies the inaccurate tolerance.
       if (solver->sol->status == QOCO_NUMERICAL_ERROR) {
         restore_best_iterate(solver);
@@ -512,7 +512,7 @@ QOCOInt qoco_solve(QOCOSolver* solver)
   stop_timer(&(work->solve_timer));
   solver->sol->status = QOCO_MAX_ITER;
   // Restore the best iterate; if it satisfies the inaccurate tolerance, the
-  // status is downgraded to QOCO_SOLVED_INACCURATE inside the helper.
+  // status is upgraded to QOCO_SOLVED_INACCURATE inside the helper.
   restore_best_iterate(solver);
   unscale_variables(work);
   copy_solution(solver);

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -473,12 +473,16 @@ QOCOInt qoco_solve(QOCOSolver* solver)
       // On numerical error, restore the best iterate seen so far. The helper
       // can upgrade the status to QOCO_SOLVED_INACCURATE if the saved
       // iterate satisfies the inaccurate tolerance.
+      unsigned char restored = 0;
       if (solver->sol->status == QOCO_NUMERICAL_ERROR) {
-        restore_best_iterate(solver);
+        restored = restore_best_iterate(solver);
       }
       unscale_variables(work);
       copy_solution(solver);
       if (solver->settings->verbose) {
+        if (restored) {
+          printf("Best iterate (%d) restored\n", work->best_iter);
+        }
         print_footer(solver->sol, solver->sol->status);
       }
       return solver->sol->status;
@@ -513,10 +517,13 @@ QOCOInt qoco_solve(QOCOSolver* solver)
   solver->sol->status = QOCO_MAX_ITER;
   // Restore the best iterate; if it satisfies the inaccurate tolerance, the
   // status is upgraded to QOCO_SOLVED_INACCURATE inside the helper.
-  restore_best_iterate(solver);
+  unsigned char restored = restore_best_iterate(solver);
   unscale_variables(work);
   copy_solution(solver);
   if (solver->settings->verbose) {
+    if (restored) {
+      printf("Best iterate (%d) restored\n", work->best_iter);
+    }
     print_footer(solver->sol, solver->sol->status);
   }
   return solver->sol->status;

--- a/src/qoco_api.c
+++ b/src/qoco_api.c
@@ -163,6 +163,19 @@ QOCOInt qoco_setup(QOCOSolver* solver, QOCOInt n, QOCOInt m, QOCOInt p,
   work->mu = 0.0;
   work->ir_iters = 0;
 
+  // Best-iterate tracking buffers (scaled space).
+  work->best_x = new_qoco_vectorf(NULL, n);
+  work->best_s = new_qoco_vectorf(NULL, m);
+  work->best_y = new_qoco_vectorf(NULL, p);
+  work->best_z = new_qoco_vectorf(NULL, m);
+  work->best_pres = 0.0;
+  work->best_dres = 0.0;
+  work->best_gap = 0.0;
+  work->best_obj = 0.0;
+  work->best_metric = 0.0;
+  work->best_iter = -1;
+  work->best_valid = 0;
+
   // Allocate Nesterov-Todd scalings and scaled variables.
   QOCOInt Wnnzfull = data->l;
   set_cpu_mode(1);
@@ -457,6 +470,12 @@ QOCOInt qoco_solve(QOCOSolver* solver)
     // Check stopping criteria.
     if (check_stopping(solver)) {
       stop_timer(&(work->solve_timer));
+      // On numerical error, restore the best iterate seen so far. The helper
+      // can downgrade the status to QOCO_SOLVED_INACCURATE if the saved
+      // iterate satisfies the inaccurate tolerance.
+      if (solver->sol->status == QOCO_NUMERICAL_ERROR) {
+        restore_best_iterate(solver);
+      }
       unscale_variables(work);
       copy_solution(solver);
       if (solver->settings->verbose) {
@@ -491,13 +510,16 @@ QOCOInt qoco_solve(QOCOSolver* solver)
   }
 
   stop_timer(&(work->solve_timer));
+  solver->sol->status = QOCO_MAX_ITER;
+  // Restore the best iterate; if it satisfies the inaccurate tolerance, the
+  // status is downgraded to QOCO_SOLVED_INACCURATE inside the helper.
+  restore_best_iterate(solver);
   unscale_variables(work);
   copy_solution(solver);
-  solver->sol->status = QOCO_MAX_ITER;
   if (solver->settings->verbose) {
     print_footer(solver->sol, solver->sol->status);
   }
-  return QOCO_MAX_ITER;
+  return solver->sol->status;
 }
 
 QOCOInt qoco_cleanup(QOCOSolver* solver)
@@ -531,6 +553,10 @@ QOCOInt qoco_cleanup(QOCOSolver* solver)
   free_qoco_vectorf(solver->work->s);
   free_qoco_vectorf(solver->work->y);
   free_qoco_vectorf(solver->work->z);
+  free_qoco_vectorf(solver->work->best_x);
+  free_qoco_vectorf(solver->work->best_s);
+  free_qoco_vectorf(solver->work->best_y);
+  free_qoco_vectorf(solver->work->best_z);
 
   // Free Nesterov-Todd scalings and scaled variables.
   free_qoco_vectorf(solver->work->W);

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -325,6 +325,33 @@ unsigned char check_stopping(QOCOSolver* solver)
   QOCOFloat gap_rel = qoco_max(1, pobj);
   gap_rel = qoco_max(gap_rel, dobj);
 
+  // Composite progress metric in inaccurate-tolerance units. metric <= 1.0
+  // means the current iterate satisfies the inaccurate stopping criterion.
+  // We track the best iterate seen so far so we can restore it on numerical
+  // error / max-iter exits.
+  QOCOFloat pres_inacc_thresh = eabsinacc + erelinacc * pres_rel;
+  QOCOFloat dres_inacc_thresh = eabsinacc + erelinacc * dres_rel;
+  QOCOFloat gap_inacc_thresh = eabsinacc + erelinacc * gap_rel;
+  QOCOFloat metric = qoco_max(pres / pres_inacc_thresh, dres / dres_inacc_thresh);
+  metric = qoco_max(metric, solver->sol->gap / gap_inacc_thresh);
+  if (isfinite(metric) && (!work->best_valid || metric < work->best_metric)) {
+    copy_arrayf(get_data_vectorf(work->x), get_data_vectorf(work->best_x),
+                work->data->n);
+    copy_arrayf(get_data_vectorf(work->s), get_data_vectorf(work->best_s),
+                work->data->m);
+    copy_arrayf(get_data_vectorf(work->y), get_data_vectorf(work->best_y),
+                work->data->p);
+    copy_arrayf(get_data_vectorf(work->z), get_data_vectorf(work->best_z),
+                work->data->m);
+    work->best_pres = pres;
+    work->best_dres = dres;
+    work->best_gap = solver->sol->gap;
+    work->best_obj = solver->sol->obj;
+    work->best_metric = metric;
+    work->best_iter = solver->sol->iters;
+    work->best_valid = 1;
+  }
+
   // If the solver stalled (stepsize = 0), increase dynamic regularization by
   // one order of magnitude and retry. If kkt_dynamic_reg would exceed
   // kkt_reg_max=1e-6, stop with an error.
@@ -359,6 +386,37 @@ unsigned char check_stopping(QOCOSolver* solver)
     return 1;
   }
   return 0;
+}
+
+void restore_best_iterate(QOCOSolver* solver)
+{
+  QOCOWorkspace* work = solver->work;
+  QOCOProblemData* data = work->data;
+  if (!work->best_valid) {
+    return;
+  }
+
+  // Copy best iterate (still in scaled space) back into the live workspace
+  // variables so that unscale_variables / copy_solution operate on it.
+  copy_arrayf(get_data_vectorf(work->best_x), get_data_vectorf(work->x),
+              data->n);
+  copy_arrayf(get_data_vectorf(work->best_s), get_data_vectorf(work->s),
+              data->m);
+  copy_arrayf(get_data_vectorf(work->best_y), get_data_vectorf(work->y),
+              data->p);
+  copy_arrayf(get_data_vectorf(work->best_z), get_data_vectorf(work->z),
+              data->m);
+  solver->sol->pres = work->best_pres;
+  solver->sol->dres = work->best_dres;
+  solver->sol->gap = work->best_gap;
+  solver->sol->obj = work->best_obj;
+
+  // If the best iterate meets the inaccurate tolerance, downgrade the status.
+  if (work->best_metric <= 1.0 &&
+      (solver->sol->status == QOCO_NUMERICAL_ERROR ||
+       solver->sol->status == QOCO_MAX_ITER)) {
+    solver->sol->status = QOCO_SOLVED_INACCURATE;
+  }
 }
 
 void copy_solution(QOCOSolver* solver)

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -389,12 +389,12 @@ unsigned char check_stopping(QOCOSolver* solver)
   return 0;
 }
 
-void restore_best_iterate(QOCOSolver* solver)
+unsigned char restore_best_iterate(QOCOSolver* solver)
 {
   QOCOWorkspace* work = solver->work;
   QOCOProblemData* data = work->data;
   if (!work->best_valid) {
-    return;
+    return 0;
   }
 
   // Copy best iterate (still in scaled space) back into the live workspace
@@ -418,6 +418,7 @@ void restore_best_iterate(QOCOSolver* solver)
        solver->sol->status == QOCO_MAX_ITER)) {
     solver->sol->status = QOCO_SOLVED_INACCURATE;
   }
+  return 1;
 }
 
 void copy_solution(QOCOSolver* solver)

--- a/src/qoco_utils.c
+++ b/src/qoco_utils.c
@@ -332,7 +332,8 @@ unsigned char check_stopping(QOCOSolver* solver)
   QOCOFloat pres_inacc_thresh = eabsinacc + erelinacc * pres_rel;
   QOCOFloat dres_inacc_thresh = eabsinacc + erelinacc * dres_rel;
   QOCOFloat gap_inacc_thresh = eabsinacc + erelinacc * gap_rel;
-  QOCOFloat metric = qoco_max(pres / pres_inacc_thresh, dres / dres_inacc_thresh);
+  QOCOFloat metric =
+      qoco_max(pres / pres_inacc_thresh, dres / dres_inacc_thresh);
   metric = qoco_max(metric, solver->sol->gap / gap_inacc_thresh);
   if (isfinite(metric) && (!work->best_valid || metric < work->best_metric)) {
     copy_arrayf(get_data_vectorf(work->x), get_data_vectorf(work->best_x),
@@ -411,7 +412,7 @@ void restore_best_iterate(QOCOSolver* solver)
   solver->sol->gap = work->best_gap;
   solver->sol->obj = work->best_obj;
 
-  // If the best iterate meets the inaccurate tolerance, downgrade the status.
+  // If the best iterate meets the inaccurate tolerance, upgrade the status.
   if (work->best_metric <= 1.0 &&
       (solver->sol->status == QOCO_NUMERICAL_ERROR ||
        solver->sol->status == QOCO_MAX_ITER)) {


### PR DESCRIPTION
Track the iterate with the lowest composite residual metric (in inaccurate-tolerance units) during solve. On QOCO_NUMERICAL_ERROR or QOCO_MAX_ITER exit, restore that iterate; if it satisfies the inaccurate tolerance, downgrade the status to QOCO_SOLVED_INACCURATE.

Rescues near-converged solves that hit a late-stage stall with a usable solution rather than failing outright. Cheap (no per-iter cost beyond a copy when a new best is found) and additive — strict SOLVED count is unchanged on all benchmarks; essentially-solved count goes up.

Benchmarks (default settings, full sets):
  - misc/iter_0024: NUMERICAL_ERROR -> SOLVED_INACCURATE
  - mm/CVXQP1_L:   NUMERICAL_ERROR -> SOLVED_INACCURATE
  - all other problems unchanged